### PR TITLE
fix: CalendarDrivenRunner silent exception + missing test assertion (closes #13)

### DIFF
--- a/scheduler/calendar_driven_runner.py
+++ b/scheduler/calendar_driven_runner.py
@@ -97,7 +97,7 @@ class CalendarDrivenRunner:
                 )
                 if event:
                     irrigation_events.append(event)
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"[WARN] Irrigation skipped for day {day_of_year}: {e}")
         
         return irrigation_events

--- a/tests/test_calendar_driven_runner.py
+++ b/tests/test_calendar_driven_runner.py
@@ -167,6 +167,7 @@ def test_tick_with_crop_management_phase_initializes_services(basic_context):
         with patch.object(runner, '_initialize_services') as mock_init:
             events = runner.tick(test_date)
             
+            mock_init.assert_called_once()
             assert isinstance(events, list)
 
 


### PR DESCRIPTION
## Summary
Quick follow-up fixes for CalendarDrivenRunner implementation from #1.

## Changes

### Fix 1: Exception Logging in `_handle_irrigation()`
**File:** `scheduler/calendar_driven_runner.py`

```python
# BEFORE
except Exception:
    pass

# AFTER
except Exception as e:
    print(f"[WARN] Irrigation skipped for day {day_of_year}: {e}")
```

Makes silent exceptions visible for debugging irrigation issues.

### Fix 2: Missing Test Assertion
**File:** `tests/test_calendar_driven_runner.py`

```python
# BEFORE
with patch.object(runner, '_initialize_services') as mock_init:
    events = runner.tick(test_date)
    assert isinstance(events, list)

# AFTER
with patch.object(runner, '_initialize_services') as mock_init:
    events = runner.tick(test_date)
    mock_init.assert_called_once()   # ← Added assertion
    assert isinstance(events, list)
```

Ensures the test actually verifies that `_initialize_services()` is called when expected.

## Testing
```bash
uv run pytest -v  # 10/10 tests passing ✓
```

## Scope
Only the two minimal fixes specified in Issue #13. No refactoring, no new features.

Closes #13