### PR TITLE
feat: Integrate DecisionManager into CalendarDrivenRunner (closes #14)

### DIFF
--- a/scheduler/calendar_driven_runner.py
+++ b/scheduler/calendar_driven_runner.py
@@ -7,6 +7,7 @@ from services.planting_plan_service import PlantingPlanService
 from services.protection_plan_service import ProtectionPlanService
 from services.irrigation_service import IrrigationSimulator
 from services.moisture_service import MoistureDataService
+from scheduler.decision_manager import DecisionManager, WorkTypePriorityStrategy
 from utils.event_logger import EventLogger
 
 
@@ -14,6 +15,7 @@ class CalendarDrivenRunner:
     def __init__(self, context: SimContext) -> None:
         self.context = context
         self.event_logger = EventLogger()
+        self.decision_manager = DecisionManager(WorkTypePriorityStrategy())
         
         self.planting_plan_service = PlantingPlanService(
             context=self.context,
@@ -37,19 +39,31 @@ class CalendarDrivenRunner:
             self._initialize_services(date)
         
         planting_ops = self.planting_plan_service.get_next_operations(date)
-        if planting_ops:
-            planting_events = self.planting_plan_service.get_events_for_ops(planting_ops, date)
-            all_events.extend(planting_events)
+        protection_ops = (
+            self.protection_plan_service.get_next_operations(date)
+            if self.protection_plan_service else []
+        )
+        all_candidate_ops = planting_ops + protection_ops
         
-        if self.protection_plan_service:
-            protection_ops = self.protection_plan_service.get_next_operations(date)
-            if protection_ops:
-                protection_events = self.protection_plan_service.get_events_for_ops(protection_ops, date)
-                all_events.extend(protection_events)
+        selected_ops = self.decision_manager.decide(all_candidate_ops) or []
+        
+        for op in selected_ops:
+            if op in planting_ops:
+                all_events.extend(
+                    self.planting_plan_service.get_events_for_ops([op], date)
+                )
+            elif op in protection_ops:
+                all_events.extend(
+                    self.protection_plan_service.get_events_for_ops([op], date)
+                )
         
         if self.irrigation_service:
-            irrigation_events = self._handle_irrigation(date)
-            all_events.extend(irrigation_events)
+            has_high_prio = any(
+                getattr(op, 'worktype', None) not in [14, 15]
+                for op in selected_ops
+            )
+            if not has_high_prio:
+                all_events.extend(self._handle_irrigation(date))
         
         for event in all_events:
             self.event_logger.log(event)

--- a/tests/test_calendar_driven_runner.py
+++ b/tests/test_calendar_driven_runner.py
@@ -198,11 +198,11 @@ def test_tick_handles_multiple_operations_same_day(basic_context, mock_planting_
         actual_date=None
     )
     
-    mock_event1 = FieldOperationEvent(worktype=1, worktype_text="Pflügen")
-    mock_event2 = FieldOperationEvent(worktype=2, worktype_text="Eggen")
-    
     mock_planting_plan_service.get_next_operations.return_value = [mock_op1, mock_op2]
-    mock_planting_plan_service.get_events_for_ops.return_value = [mock_event1, mock_event2]
+    mock_planting_plan_service.get_events_for_ops.side_effect = lambda ops, date: [
+        FieldOperationEvent(worktype=op.worktype, worktype_text=op.operation) for op in ops
+    ]
+    mock_planting_plan_service.active_phase = None
     
     with patch('scheduler.calendar_driven_runner.PlantingPlanService', return_value=mock_planting_plan_service):
         runner = CalendarDrivenRunner(basic_context)
@@ -227,3 +227,91 @@ def test_tick_integration_with_real_planting_plan(basic_context):
     events = runner.tick(test_date)
     
     assert isinstance(events, list)
+
+
+def test_tick_high_prio_op_suppresses_low_prio(basic_context, mock_planting_plan_service):
+    """
+    Test 9: Wenn Pflügen (worktype=1) und Spritzen (worktype=14) am selben Tag fällig sind,
+    wird nur Pflügen ausgeführt. Spritzen wird nicht ausgeführt (actual_date bleibt None).
+    """
+    test_date = datetime.date(2024, 10, 15)
+    
+    high_prio_op = FieldOperation(
+        sequence=1,
+        operation="Pflügen",
+        worktype=1,
+        planned_date=test_date,
+        actual_date=None,
+        duration_per_ha=2.0,
+        working_width=3.0,
+        fuel_consumption=15.0
+    )
+    
+    low_prio_op = FieldOperation(
+        sequence=2,
+        operation="Spritzen",
+        worktype=14,
+        planned_date=test_date,
+        actual_date=None,
+        duration_per_ha=0.2,
+        working_width=18.0,
+        fuel_consumption=1.0
+    )
+    
+    mock_planting_plan_service.get_next_operations.return_value = [high_prio_op, low_prio_op]
+    mock_planting_plan_service.get_events_for_ops.side_effect = lambda ops, date: [
+        FieldOperationEvent(worktype=op.worktype, worktype_text=op.operation) for op in ops
+    ]
+    mock_planting_plan_service.active_phase = None
+    
+    with patch('scheduler.calendar_driven_runner.PlantingPlanService', return_value=mock_planting_plan_service):
+        runner = CalendarDrivenRunner(basic_context)
+        events = runner.tick(test_date)
+    
+    assert len(events) == 1
+    assert events[0].worktype == 1
+    assert low_prio_op.actual_date is None
+
+
+def test_tick_all_low_prio_ops_execute_when_no_high_prio(basic_context, mock_planting_plan_service):
+    """
+    Test 10: Wenn nur niedrig-priorisierte Ops (worktype=14, 15) fällig sind,
+    werden alle ausgeführt.
+    """
+    test_date = datetime.date(2024, 10, 15)
+    
+    low_prio_op1 = FieldOperation(
+        sequence=1,
+        operation="Spritzen",
+        worktype=14,
+        planned_date=test_date,
+        actual_date=None,
+        duration_per_ha=0.2,
+        working_width=18.0,
+        fuel_consumption=1.0
+    )
+    
+    low_prio_op2 = FieldOperation(
+        sequence=2,
+        operation="Bewässern",
+        worktype=15,
+        planned_date=test_date,
+        actual_date=None,
+        duration_per_ha=1.0,
+        working_width=10.0,
+        fuel_consumption=5.0
+    )
+    
+    mock_planting_plan_service.get_next_operations.return_value = [low_prio_op1, low_prio_op2]
+    mock_planting_plan_service.get_events_for_ops.side_effect = lambda ops, date: [
+        FieldOperationEvent(worktype=op.worktype, worktype_text=op.operation) for op in ops
+    ]
+    mock_planting_plan_service.active_phase = None
+    
+    with patch('scheduler.calendar_driven_runner.PlantingPlanService', return_value=mock_planting_plan_service):
+        runner = CalendarDrivenRunner(basic_context)
+        events = runner.tick(test_date)
+    
+    assert len(events) == 2
+    assert events[0].worktype == 14
+    assert events[1].worktype == 15


### PR DESCRIPTION
## Summary
Integrates the existing `DecisionManager` with `WorkTypePriorityStrategy` into `CalendarDrivenRunner` to handle operation conflicts based on priority.

## Decision: Option A Confirmed
When multiple operations are scheduled for the same day, high-priority operations (worktype != 14, 15) are executed, while low-priority operations (Spritzen=14, Bewässern=15) are deferred. Deferred operations will reappear in the next `tick()` call since their `actual_date` remains `None`.

## Changes

### Core Implementation
**File:** `scheduler/calendar_driven_runner.py`

1. **Added DecisionManager initialization:**
```python
from scheduler.decision_manager import DecisionManager, WorkTypePriorityStrategy

def __init__(self, context: SimContext) -> None:
    # ...
    self.decision_manager = DecisionManager(WorkTypePriorityStrategy())
```

2. **Refactored `tick()` method:**
   - **Collect** all candidate operations first (planting + protection)
   - **Decide** which operations to execute using `DecisionManager.decide()`
   - **Generate events** only for selected operations
   - This prevents premature `actual_date` setting on deferred operations

3. **Irrigation logic updated:**
   - Only runs when no high-priority operations are scheduled
   - Prevents irrigation conflicts with field work

### New Tests
**File:** `tests/test_calendar_driven_runner.py`

**Test 9:** `test_tick_high_prio_op_suppresses_low_prio`
- Verifies that when Pflügen (worktype=1) and Spritzen (worktype=14) are both scheduled
- Only Pflügen executes
- Spritzen's `actual_date` remains `None` (will retry tomorrow)

**Test 10:** `test_tick_all_low_prio_ops_execute_when_no_high_prio`
- Verifies that when only low-priority ops are scheduled
- All execute (existing WorkTypePriorityStrategy behavior)

## Testing
```bash
uv run pytest -v  # 12/12 tests passing ✓
```

All existing tests continue to pass, demonstrating backward compatibility.

## Key Benefits
- ✅ Prevents operation conflicts (e.g., can't spray while plowing)
- ✅ Low-priority operations automatically retry next day
- ✅ Leverages existing, tested `DecisionManager` infrastructure
- ✅ No changes to `DecisionManager` or strategies needed

Closes #14