### PR TITLE
feat: Add TickScheduler for daily tick orchestration (closes #2)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "netCDF4>=1.5.0",
     "python-dotenv>=0.19.0",
     "requests>=2.26.0",
+    "apscheduler>=3.10",
 ]
 
 [project.optional-dependencies]

--- a/scheduler/tick_scheduler.py
+++ b/scheduler/tick_scheduler.py
@@ -1,0 +1,60 @@
+import datetime
+import time
+from typing import List
+
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from models.sim_context import SimContext
+from scheduler.calendar_driven_runner import CalendarDrivenRunner
+
+
+class TickScheduler:
+    def __init__(self, contexts: List[SimContext], tick_time: str = "06:00") -> None:
+        self.contexts = contexts
+        self.tick_time = tick_time
+        
+        self.tick_hour, self.tick_minute = self._parse_tick_time(tick_time)
+        
+        self.runners = {}
+        for context in contexts:
+            self.runners[context.field_id] = CalendarDrivenRunner(context)
+        
+        self.scheduler = BackgroundScheduler()
+        self.scheduler.add_job(
+            self.daily_tick,
+            CronTrigger(hour=self.tick_hour, minute=self.tick_minute),
+            id='daily_tick'
+        )
+        
+        self._running = False
+    
+    def _parse_tick_time(self, tick_time: str) -> tuple[int, int]:
+        parts = tick_time.split(":")
+        hour = int(parts[0])
+        minute = int(parts[1])
+        return hour, minute
+    
+    def daily_tick(self) -> None:
+        today = datetime.date.today()
+        for field_id, runner in self.runners.items():
+            try:
+                events = runner.tick(today)
+                print(f"[INFO] Field {field_id}: {len(events)} events on {today}")
+            except Exception as e:
+                print(f"[ERROR] Field {field_id} tick failed: {e}")
+    
+    def start(self) -> None:
+        self.scheduler.start()
+        self._running = True
+        
+        try:
+            while self._running:
+                time.sleep(1)
+        except (KeyboardInterrupt, SystemExit):
+            self.stop()
+    
+    def stop(self) -> None:
+        self._running = False
+        if self.scheduler.running:
+            self.scheduler.shutdown(wait=False)

--- a/tests/test_tick_scheduler.py
+++ b/tests/test_tick_scheduler.py
@@ -1,0 +1,135 @@
+import datetime
+from unittest.mock import Mock, patch, call
+import pytest
+
+from models.sim_context import SimContext
+from scheduler.tick_scheduler import TickScheduler
+
+
+@pytest.fixture
+def sample_contexts():
+    return [
+        SimContext(
+            field_id=1,
+            field_name="Field 1",
+            field_size=10.0,
+            start_date=datetime.datetime(2024, 10, 1),
+            crop_type="Potato",
+            variety="Belana"
+        ),
+        SimContext(
+            field_id=2,
+            field_name="Field 2",
+            field_size=15.0,
+            start_date=datetime.datetime(2024, 10, 1),
+            crop_type="Potato",
+            variety="Belana"
+        )
+    ]
+
+
+def test_daily_tick_calls_tick_for_each_field(sample_contexts):
+    """
+    Test 1: daily_tick() ruft tick(today) für jedes Feld auf
+    """
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
+        mock_runner_1 = Mock()
+        mock_runner_1.tick.return_value = []
+        mock_runner_2 = Mock()
+        mock_runner_2.tick.return_value = []
+        
+        MockRunner.side_effect = [mock_runner_1, mock_runner_2]
+        
+        scheduler = TickScheduler(sample_contexts)
+        
+        with patch('scheduler.tick_scheduler.datetime') as mock_datetime:
+            mock_datetime.date.today.return_value = datetime.date(2024, 11, 15)
+            
+            scheduler.daily_tick()
+            
+            mock_runner_1.tick.assert_called_once_with(datetime.date(2024, 11, 15))
+            mock_runner_2.tick.assert_called_once_with(datetime.date(2024, 11, 15))
+
+
+def test_daily_tick_field_error_does_not_stop_others(sample_contexts):
+    """
+    Test 2: Fehler in einem Feld stoppt nicht andere Felder
+    """
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
+        mock_runner_1 = Mock()
+        mock_runner_1.tick.side_effect = Exception("Field 1 error")
+        mock_runner_2 = Mock()
+        mock_runner_2.tick.return_value = []
+        
+        MockRunner.side_effect = [mock_runner_1, mock_runner_2]
+        
+        scheduler = TickScheduler(sample_contexts)
+        
+        with patch('scheduler.tick_scheduler.datetime') as mock_datetime:
+            mock_datetime.date.today.return_value = datetime.date(2024, 11, 15)
+            
+            scheduler.daily_tick()
+            
+            mock_runner_1.tick.assert_called_once()
+            mock_runner_2.tick.assert_called_once()
+
+
+def test_tick_scheduler_creates_runner_per_context(sample_contexts):
+    """
+    Test 3: TickScheduler erstellt einen Runner pro SimContext
+    """
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
+        MockRunner.return_value = Mock()
+        
+        scheduler = TickScheduler(sample_contexts)
+        
+        assert len(scheduler.runners) == len(sample_contexts)
+        assert 1 in scheduler.runners
+        assert 2 in scheduler.runners
+
+
+def test_daily_tick_passes_today_to_runners(sample_contexts):
+    """
+    Test 4: daily_tick() übergibt datetime.date.today() an jeden Runner
+    """
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
+        mock_runner = Mock()
+        mock_runner.tick.return_value = []
+        MockRunner.return_value = mock_runner
+        
+        scheduler = TickScheduler(sample_contexts)
+        
+        with patch('scheduler.tick_scheduler.datetime') as mock_datetime:
+            test_date = datetime.date(2024, 12, 25)
+            mock_datetime.date.today.return_value = test_date
+            
+            scheduler.daily_tick()
+            
+            for call_args in mock_runner.tick.call_args_list:
+                assert call_args[0][0] == test_date
+
+
+def test_tick_scheduler_parses_tick_time():
+    """
+    Test 5: TickScheduler parst tick_time korrekt
+    """
+    context = SimContext(field_id=1, field_name="Test")
+    
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner'):
+        scheduler = TickScheduler([context], tick_time="14:30")
+        
+        assert scheduler.tick_hour == 14
+        assert scheduler.tick_minute == 30
+
+
+def test_tick_scheduler_default_tick_time():
+    """
+    Test 6: TickScheduler verwendet Standard-Zeit 06:00
+    """
+    context = SimContext(field_id=1, field_name="Test")
+    
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner'):
+        scheduler = TickScheduler([context])
+        
+        assert scheduler.tick_hour == 6
+        assert scheduler.tick_minute == 0


### PR DESCRIPTION
## Summary
Implements Issue #2: Daily tick scheduler that orchestrates `CalendarDrivenRunner.tick()` execution for multiple fields at a configurable time each day.

## Changes

### New Dependency
**File:** `pyproject.toml`
- Added `apscheduler>=3.10` to project dependencies

### Core Implementation
**File:** `scheduler/tick_scheduler.py`

```python
class TickScheduler:
    def __init__(self, contexts: List[SimContext], tick_time: str = "06:00")
    def daily_tick(self) -> None
    def start(self) -> None  # Blocking
    def stop(self) -> None
```

**Key Features:**
1. **Multi-field orchestration:** Creates one `CalendarDrivenRunner` per `SimContext` (field)
2. **Configurable schedule:** Daily tick at specified time (default 06:00)
3. **Error isolation:** Exception in one field doesn't stop others
4. **Blocking operation:** `start()` blocks until `stop()` is called (daemon-ready)
5. **APScheduler integration:** Uses `BackgroundScheduler` with `CronTrigger`

### Implementation Details

**`daily_tick()` method:**
- Calls `runner.tick(datetime.date.today())` for each field
- Logs success: `[INFO] Field {id}: {count} events on {date}`
- Logs errors: `[ERROR] Field {id} tick failed: {exception}`
- Continues processing remaining fields after errors

**`start()` method:**
- Starts APScheduler in background
- Blocks with `while True: time.sleep(1)` loop
- Handles `KeyboardInterrupt` and `SystemExit` gracefully

### Comprehensive Tests
**File:** `tests/test_tick_scheduler.py`

**Test 1:** `test_daily_tick_calls_tick_for_each_field`
- Verifies `tick()` is called for every field

**Test 2:** `test_daily_tick_field_error_does_not_stop_others`
- Field A throws exception, Field B still executes

**Test 3:** `test_tick_scheduler_creates_runner_per_context`
- One runner per SimContext, indexed by `field_id`

**Test 4:** `test_daily_tick_passes_today_to_runners`
- Verifies `datetime.date.today()` is passed to each runner

**Test 5:** `test_tick_scheduler_parses_tick_time`
- Custom time "14:30" → hour=14, minute=30

**Test 6:** `test_tick_scheduler_default_tick_time`
- Default time → hour=6, minute=0

## Testing
```bash
uv run pytest -v  # 18/18 tests passing ✓
```

All existing tests continue to pass (10 CalendarDrivenRunner + 2 moisture + 6 TickScheduler).

## Not in Scope (Future Issues)
- State persistence → Issue #3
- `.env` configuration → Issue #9
- Graceful SIGTERM shutdown → Issue #7
- Loading fields from API → Issue #11

## Architecture Notes
- **Testable design:** Business logic (`daily_tick()`) is separate from APScheduler internals
- **No state management:** TickScheduler is stateless (state loading comes in Issue #3)
- **Daemon-ready:** Blocking `start()` method suitable for systemd/supervisor

Closes #2