### PR TITLE
feat: Add StateManager for persistent field simulation state (closes #3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,6 @@ USER_STORIES.md
 worktypes.txt   
 simulation_events.json
 .DS_Store
+
+# State persistence
+state/

--- a/scheduler/calendar_driven_runner.py
+++ b/scheduler/calendar_driven_runner.py
@@ -115,3 +115,59 @@ class CalendarDrivenRunner:
             print(f"[WARN] Irrigation skipped for day {day_of_year}: {e}")
         
         return irrigation_events
+
+    def get_state_snapshot(self, last_tick_date: datetime.date | None = None):
+        from utils.state_manager import FieldStateSnapshot
+        
+        planting_ops = []
+        for phase in self.planting_plan_service.planting_plan.phases:
+            for op in phase.operations:
+                planting_ops.append({
+                    "phase": phase.phase_name,
+                    "sequence": op.sequence,
+                    "actual_date": op.actual_date.isoformat() if op.actual_date else None
+                })
+        
+        protection_ops = []
+        if self.protection_plan_service:
+            for op in self.protection_plan_service.operations:
+                protection_ops.append({
+                    "sequence": op.sequence,
+                    "actual_date": op.actual_date.isoformat() if op.actual_date else None
+                })
+        
+        return FieldStateSnapshot(
+            field_id=self.context.field_id,
+            last_tick_date=last_tick_date,
+            context=self.context,
+            planting_ops=planting_ops,
+            protection_ops=protection_ops
+        )
+
+    def apply_state_snapshot(self, snapshot) -> None:
+        for op_data in snapshot.planting_ops:
+            phase_name = op_data["phase"]
+            sequence = op_data["sequence"]
+            actual_date_str = op_data.get("actual_date")
+            
+            for phase in self.planting_plan_service.planting_plan.phases:
+                if phase.phase_name == phase_name:
+                    for op in phase.operations:
+                        if op.sequence == sequence:
+                            if actual_date_str:
+                                op.actual_date = datetime.datetime.fromisoformat(actual_date_str)
+                            break
+        
+        if snapshot.protection_ops and self._should_initialize_services():
+            self._initialize_services(self.context.start_date)
+        
+        if self.protection_plan_service and snapshot.protection_ops:
+            for op_data in snapshot.protection_ops:
+                sequence = op_data["sequence"]
+                actual_date_str = op_data.get("actual_date")
+                
+                for op in self.protection_plan_service.operations:
+                    if op.sequence == sequence:
+                        if actual_date_str:
+                            op.actual_date = datetime.datetime.fromisoformat(actual_date_str)
+                        break

--- a/scheduler/calendar_driven_runner.py
+++ b/scheduler/calendar_driven_runner.py
@@ -132,7 +132,6 @@ class CalendarDrivenRunner:
         if self.protection_plan_service:
             for op in self.protection_plan_service.operations:
                 protection_ops.append({
-                    "sequence": op.sequence,
                     "actual_date": op.actual_date.isoformat() if op.actual_date else None
                 })
         
@@ -158,16 +157,14 @@ class CalendarDrivenRunner:
                                 op.actual_date = datetime.datetime.fromisoformat(actual_date_str)
                             break
         
-        if snapshot.protection_ops and self._should_initialize_services():
-            self._initialize_services(self.context.start_date)
-        
-        if self.protection_plan_service and snapshot.protection_ops:
-            for op_data in snapshot.protection_ops:
-                sequence = op_data["sequence"]
-                actual_date_str = op_data.get("actual_date")
-                
-                for op in self.protection_plan_service.operations:
-                    if op.sequence == sequence:
+        if snapshot.protection_ops:
+            if not self.protection_plan_service:
+                self._initialize_services(self.context.start_date)
+            if self.protection_plan_service:
+                for idx, op_data in enumerate(snapshot.protection_ops):
+                    actual_date_str = op_data.get("actual_date")
+                    
+                    if idx < len(self.protection_plan_service.operations):
+                        op = self.protection_plan_service.operations[idx]
                         if actual_date_str:
                             op.actual_date = datetime.datetime.fromisoformat(actual_date_str)
-                        break

--- a/scheduler/tick_scheduler.py
+++ b/scheduler/tick_scheduler.py
@@ -7,18 +7,25 @@ from apscheduler.triggers.cron import CronTrigger
 
 from models.sim_context import SimContext
 from scheduler.calendar_driven_runner import CalendarDrivenRunner
+from utils.state_manager import StateManager
 
 
 class TickScheduler:
-    def __init__(self, contexts: List[SimContext], tick_time: str = "06:00") -> None:
+    def __init__(self, contexts: List[SimContext], tick_time: str = "06:00", state_dir: str = "./state") -> None:
         self.contexts = contexts
         self.tick_time = tick_time
+        self.state_manager = StateManager(state_dir)
         
         self.tick_hour, self.tick_minute = self._parse_tick_time(tick_time)
         
         self.runners = {}
         for context in contexts:
-            self.runners[context.field_id] = CalendarDrivenRunner(context)
+            runner = CalendarDrivenRunner(context)
+            snapshot = self.state_manager.load(context.field_id)
+            if snapshot:
+                runner.apply_state_snapshot(snapshot)
+                print(f"[INFO] Field {context.field_id}: state restored (last tick: {snapshot.last_tick_date})")
+            self.runners[context.field_id] = runner
         
         self.scheduler = BackgroundScheduler()
         self.scheduler.add_job(
@@ -40,6 +47,7 @@ class TickScheduler:
         for field_id, runner in self.runners.items():
             try:
                 events = runner.tick(today)
+                self.state_manager.save(runner)
                 print(f"[INFO] Field {field_id}: {len(events)} events on {today}")
             except Exception as e:
                 print(f"[ERROR] Field {field_id} tick failed: {e}")

--- a/scheduler/tick_scheduler.py
+++ b/scheduler/tick_scheduler.py
@@ -47,7 +47,7 @@ class TickScheduler:
         for field_id, runner in self.runners.items():
             try:
                 events = runner.tick(today)
-                self.state_manager.save(runner)
+                self.state_manager.save(runner, today)
                 print(f"[INFO] Field {field_id}: {len(events)} events on {today}")
             except Exception as e:
                 print(f"[ERROR] Field {field_id} tick failed: {e}")

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -157,17 +157,30 @@ def test_apply_snapshot_restores_protection_ops(basic_context):
     """
     Test 7: apply_state_snapshot() stellt auch Protection-Ops wieder her
     """
+    from utils.state_manager import FieldStateSnapshot
+    
+    snapshot = FieldStateSnapshot(
+        field_id=42,
+        last_tick_date=datetime.date(2025, 6, 1),
+        context=basic_context,
+        planting_ops=[
+            {"phase": "soil_preparation", "sequence": 1, "actual_date": "2024-10-05T08:30:00"}
+        ],
+        protection_ops=[
+            {"actual_date": "2025-06-10T09:00:00"},
+            {"actual_date": None}
+        ]
+    )
+    
     runner = CalendarDrivenRunner(basic_context)
+    runner.apply_state_snapshot(snapshot)
     
-    runner.tick(datetime.date(2025, 5, 1))
+    assert runner.protection_plan_service is not None, "Protection service should be initialized when snapshot has protection_ops"
+    assert len(runner.protection_plan_service.operations) >= 2, "Protection operations should exist"
     
-    if runner.protection_plan_service:
-        snapshot = runner.get_state_snapshot(last_tick_date=datetime.date(2025, 5, 1))
-        
-        runner2 = CalendarDrivenRunner(basic_context)
-        runner2.apply_state_snapshot(snapshot)
-        
-        if runner2.protection_plan_service and len(snapshot.protection_ops) > 0:
-            first_protection_op = runner2.protection_plan_service.operations[0]
-            if snapshot.protection_ops[0].get('actual_date'):
-                assert first_protection_op.actual_date is not None
+    first_op = runner.protection_plan_service.operations[0]
+    assert first_op.actual_date is not None, "First protection op should have actual_date restored"
+    assert first_op.actual_date == datetime.datetime(2025, 6, 10, 9, 0, 0), "Restored actual_date should match snapshot"
+    
+    second_op = runner.protection_plan_service.operations[1]
+    assert second_op.actual_date is None, "Second protection op should not have actual_date"

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1,0 +1,173 @@
+import datetime
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+import pytest
+
+from models.sim_context import SimContext
+from models.planting_plan import FieldOperation
+from scheduler.calendar_driven_runner import CalendarDrivenRunner
+from utils.state_manager import StateManager, FieldStateSnapshot
+
+
+@pytest.fixture
+def basic_context():
+    return SimContext(
+        field_id=42,
+        field_name="Test Field",
+        field_size=10.0,
+        start_date=datetime.datetime(2024, 10, 1),
+        crop_type="Potato",
+        variety="Belana"
+    )
+
+
+def test_save_creates_json_file(tmp_path, basic_context):
+    """
+    Test 1: save() erstellt Datei mit korrektem Inhalt
+    """
+    state_manager = StateManager(str(tmp_path))
+    
+    runner = CalendarDrivenRunner(basic_context)
+    runner.tick(datetime.date(2024, 10, 15))
+    
+    state_manager.save(runner)
+    
+    state_file = tmp_path / "field_42.json"
+    assert state_file.exists()
+    
+    with open(state_file, 'r') as f:
+        data = json.load(f)
+    
+    assert data["field_id"] == 42
+    assert "context" in data
+    assert "planting_operations" in data
+    assert "protection_operations" in data
+
+
+def test_load_returns_none_for_unknown_field(tmp_path):
+    """
+    Test 2: load() gibt None zurück für unbekanntes Feld
+    """
+    state_manager = StateManager(str(tmp_path))
+    snapshot = state_manager.load(999)
+    
+    assert snapshot is None
+
+
+def test_save_and_load_roundtrip(tmp_path, basic_context):
+    """
+    Test 3: load() stellt gespeicherten State korrekt wieder her
+    """
+    state_manager = StateManager(str(tmp_path))
+    
+    runner = CalendarDrivenRunner(basic_context)
+    runner.tick(datetime.date(2024, 10, 15))
+    
+    state_manager.save(runner)
+    
+    snapshot = state_manager.load(42)
+    
+    assert snapshot is not None
+    assert snapshot.field_id == 42
+    assert snapshot.context.field_id == 42
+    assert len(snapshot.planting_ops) > 0
+
+
+def test_apply_snapshot_prevents_re_execution(basic_context):
+    """
+    Test 4 (Integration): apply_state_snapshot() verhindert Re-Execution
+    """
+    runner = CalendarDrivenRunner(basic_context)
+    events_first = runner.tick(datetime.date(2024, 11, 1))
+    
+    snapshot = runner.get_state_snapshot(last_tick_date=datetime.date(2024, 11, 1))
+    
+    runner2 = CalendarDrivenRunner(basic_context)
+    runner2.apply_state_snapshot(snapshot)
+    
+    events_second = runner2.tick(datetime.date(2024, 11, 1))
+    assert len(events_second) == 0
+
+
+def test_tick_scheduler_restores_state_on_init(tmp_path):
+    """
+    Test 5: TickScheduler lädt State beim Start
+    """
+    from scheduler.tick_scheduler import TickScheduler
+    
+    context = SimContext(
+        field_id=1,
+        field_name="Field 1",
+        field_size=10.0,
+        start_date=datetime.datetime(2024, 10, 1),
+        crop_type="Potato",
+        variety="Belana"
+    )
+    
+    state_file = tmp_path / "field_1.json"
+    state_data = {
+        "field_id": 1,
+        "last_tick_date": "2024-11-01",
+        "context": {
+            "field_id": 1,
+            "field_name": "Field 1",
+            "field_size": 10.0,
+            "soil_type": "sand",
+            "start_date": "2024-10-01T00:00:00",
+            "crop_type": "Potato",
+            "variety": "Belana",
+            "fuel_variation": 0.1
+        },
+        "planting_operations": [
+            {"phase": "soil_preparation", "sequence": 1, "actual_date": "2024-10-05T08:30:00"}
+        ],
+        "protection_operations": []
+    }
+    
+    with open(state_file, 'w') as f:
+        json.dump(state_data, f)
+    
+    scheduler = TickScheduler([context], state_dir=str(tmp_path))
+    
+    assert 1 in scheduler.runners
+    runner = scheduler.runners[1]
+    
+    soil_prep_phase = runner.planting_plan_service.planting_plan.phases[0]
+    first_op = soil_prep_phase.operations[0]
+    assert first_op.actual_date is not None
+
+
+def test_get_state_snapshot_captures_current_state(basic_context):
+    """
+    Test 6: get_state_snapshot() erfasst den aktuellen State korrekt
+    """
+    runner = CalendarDrivenRunner(basic_context)
+    runner.tick(datetime.date(2024, 10, 15))
+    
+    snapshot = runner.get_state_snapshot(last_tick_date=datetime.date(2024, 10, 15))
+    
+    assert snapshot.field_id == 42
+    assert snapshot.last_tick_date == datetime.date(2024, 10, 15)
+    assert snapshot.context.field_id == 42
+    assert len(snapshot.planting_ops) > 0
+
+
+def test_apply_snapshot_restores_protection_ops(basic_context):
+    """
+    Test 7: apply_state_snapshot() stellt auch Protection-Ops wieder her
+    """
+    runner = CalendarDrivenRunner(basic_context)
+    
+    runner.tick(datetime.date(2025, 5, 1))
+    
+    if runner.protection_plan_service:
+        snapshot = runner.get_state_snapshot(last_tick_date=datetime.date(2025, 5, 1))
+        
+        runner2 = CalendarDrivenRunner(basic_context)
+        runner2.apply_state_snapshot(snapshot)
+        
+        if runner2.protection_plan_service and len(snapshot.protection_ops) > 0:
+            first_protection_op = runner2.protection_plan_service.operations[0]
+            if snapshot.protection_ops[0].get('actual_date'):
+                assert first_protection_op.actual_date is not None

--- a/utils/state_manager.py
+++ b/utils/state_manager.py
@@ -24,8 +24,8 @@ class StateManager:
         self.state_dir = Path(state_dir)
         self.state_dir.mkdir(parents=True, exist_ok=True)
     
-    def save(self, runner: "CalendarDrivenRunner") -> None:
-        snapshot = runner.get_state_snapshot()
+    def save(self, runner: "CalendarDrivenRunner", tick_date: datetime.date | None = None) -> None:
+        snapshot = runner.get_state_snapshot(last_tick_date=tick_date)
         
         state_file = self.state_dir / f"field_{snapshot.field_id}.json"
         

--- a/utils/state_manager.py
+++ b/utils/state_manager.py
@@ -1,0 +1,83 @@
+import datetime
+import json
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from models.sim_context import SimContext
+
+if TYPE_CHECKING:
+    from scheduler.calendar_driven_runner import CalendarDrivenRunner
+
+
+@dataclass
+class FieldStateSnapshot:
+    field_id: int
+    last_tick_date: datetime.date | None
+    context: SimContext
+    planting_ops: list[dict]
+    protection_ops: list[dict]
+
+
+class StateManager:
+    def __init__(self, state_dir: str = "./state") -> None:
+        self.state_dir = Path(state_dir)
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+    
+    def save(self, runner: "CalendarDrivenRunner") -> None:
+        snapshot = runner.get_state_snapshot()
+        
+        state_file = self.state_dir / f"field_{snapshot.field_id}.json"
+        
+        data = {
+            "field_id": snapshot.field_id,
+            "last_tick_date": snapshot.last_tick_date.isoformat() if snapshot.last_tick_date else None,
+            "context": {
+                "field_id": snapshot.context.field_id,
+                "field_name": snapshot.context.field_name,
+                "field_size": snapshot.context.field_size,
+                "soil_type": snapshot.context.soil_type,
+                "start_date": snapshot.context.start_date.isoformat(),
+                "crop_type": snapshot.context.crop_type,
+                "variety": snapshot.context.variety,
+                "fuel_variation": snapshot.context.fuel_variation
+            },
+            "planting_operations": snapshot.planting_ops,
+            "protection_operations": snapshot.protection_ops
+        }
+        
+        with open(state_file, 'w') as f:
+            json.dump(data, f, indent=2)
+    
+    def load(self, field_id: int) -> FieldStateSnapshot | None:
+        state_file = self.state_dir / f"field_{field_id}.json"
+        
+        if not state_file.exists():
+            return None
+        
+        with open(state_file, 'r') as f:
+            data = json.load(f)
+        
+        context_data = data["context"]
+        context = SimContext(
+            field_id=context_data["field_id"],
+            field_name=context_data["field_name"],
+            field_size=context_data["field_size"],
+            soil_type=context_data.get("soil_type", "sand"),
+            start_date=datetime.datetime.fromisoformat(context_data["start_date"]),
+            crop_type=context_data["crop_type"],
+            variety=context_data["variety"],
+            fuel_variation=context_data.get("fuel_variation", 0.1)
+        )
+        
+        last_tick_date = None
+        if data.get("last_tick_date"):
+            last_tick_date = datetime.date.fromisoformat(data["last_tick_date"])
+        
+        return FieldStateSnapshot(
+            field_id=data["field_id"],
+            last_tick_date=last_tick_date,
+            context=context,
+            planting_ops=data.get("planting_operations", []),
+            protection_ops=data.get("protection_operations", [])
+        )


### PR DESCRIPTION
## Summary
Implements Issue #3: Persistent state management to prevent duplicate event execution after service restarts.

## The Problem
`CalendarDrivenRunner` is stateful - `PlantingPlanService` and `ProtectionPlanService` track which `FieldOperation` objects have been executed via `actual_date`. Without persistence, a service restart would lose this state and re-send all events.

## Solution
JSON-based state persistence that saves and restores `FieldOperation.actual_date` for all operations.

## Changes

### New Components

**File:** `utils/state_manager.py`

```python
@dataclass
class FieldStateSnapshot:
    field_id: int
    last_tick_date: datetime.date | None
    context: SimContext
    planting_ops: list[dict]
    protection_ops: list[dict]

class StateManager:
    def __init__(self, state_dir: str = "./state")
    def save(self, runner: CalendarDrivenRunner) -> None
    def load(self, field_id: int) -> FieldStateSnapshot | None
```

**State File Format** (`state/field_42.json`):
```json
{
  "field_id": 42,
  "last_tick_date": "2025-03-15",
  "context": {...},
  "planting_operations": [
    {"phase": "soil_preparation", "sequence": 1, "actual_date": "2024-10-05T08:30:00"}
  ],
  "protection_operations": [...]
}
```

### CalendarDrivenRunner Extensions

**File:** `scheduler/calendar_driven_runner.py`

Added two new methods:

1. **`get_state_snapshot(last_tick_date=None)`**
   - Extracts current state from all `FieldOperation` objects
   - Returns `FieldStateSnapshot` with phase, sequence, and actual_date

2. **`apply_state_snapshot(snapshot)`**
   - Restores state by finding matching operations (via phase + sequence)
   - Sets `actual_date` on all previously executed operations
   - Prevents re-execution of completed operations

### TickScheduler Integration

**File:** `scheduler/tick_scheduler.py`

**On initialization:**
- Loads state for each field via `StateManager.load(field_id)`
- Calls `runner.apply_state_snapshot(snapshot)` if state exists
- Logs: `[INFO] Field {id}: state restored (last tick: {date})`

**After each tick:**
- Saves state via `StateManager.save(runner)`
- Ensures state is persisted before next tick

### Configuration

**File:** `.gitignore`
- Added `state/` directory to prevent committing state files

## Test Coverage (7 New Tests)

**File:** `tests/test_state_manager.py`

1. **test_save_creates_json_file** - Verifies JSON file creation with correct structure
2. **test_load_returns_none_for_unknown_field** - Handles missing state gracefully
3. **test_save_and_load_roundtrip** - Full save/load cycle validation
4. **test_apply_snapshot_prevents_re_execution** - Core idempotency test
5. **test_tick_scheduler_restores_state_on_init** - Integration with TickScheduler
6. **test_get_state_snapshot_captures_current_state** - Snapshot creation validation
7. **test_apply_snapshot_restores_protection_ops** - Protection operations state restoration

## Testing
```bash
uv run pytest -v  # 25/25 tests passing ✓
```

All existing tests continue to pass (10 CalendarDrivenRunner + 2 moisture + 6 TickScheduler + 7 StateManager).

## Key Benefits
- ✅ **Prevents duplicate events** after service restarts
- ✅ **Automatic state persistence** after every tick
- ✅ **Graceful degradation** - missing state files don't cause errors
- ✅ **Per-field isolation** - each field has independent state file
- ✅ **Human-readable** JSON format for debugging

## Example State Restoration Flow
```python
# Service starts
scheduler = TickScheduler([context], state_dir="./state")
# → Loads state/field_42.json
# → Restores actual_date on all completed operations
# → Logs: "[INFO] Field 42: state restored (last tick: 2025-03-15)"

# Daily tick runs
scheduler.daily_tick()
# → Executes tick() for each field
# → Saves updated state to state/field_42.json
# → Only new operations generate events
```

## Not in Scope (Future Issues)
- `.env` configuration of `state_dir` → Issue #9
- Retry queue → Issue #5
- Loading fields from API → Issue #11

Closes #3