### PR TITLE
feat: Add DigiZertClient HTTP event dispatcher (closes #4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DIGIZERT_API_URL=https://api.digizert.example.com/operations/
+DIGIZERT_API_TOKEN=
+API_TIMEOUT_SECONDS=10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "python-dotenv>=0.19.0",
     "requests>=2.26.0",
     "apscheduler>=3.10",
+    "httpx>=0.27",
 ]
 
 [project.optional-dependencies]

--- a/scheduler/tick_scheduler.py
+++ b/scheduler/tick_scheduler.py
@@ -11,10 +11,11 @@ from utils.state_manager import StateManager
 
 
 class TickScheduler:
-    def __init__(self, contexts: List[SimContext], tick_time: str = "06:00", state_dir: str = "./state") -> None:
+    def __init__(self, contexts: List[SimContext], tick_time: str = "06:00", state_dir: str = "./state", event_dispatcher=None) -> None:
         self.contexts = contexts
         self.tick_time = tick_time
         self.state_manager = StateManager(state_dir)
+        self.event_dispatcher = event_dispatcher
         
         self.tick_hour, self.tick_minute = self._parse_tick_time(tick_time)
         
@@ -47,6 +48,9 @@ class TickScheduler:
         for field_id, runner in self.runners.items():
             try:
                 events = runner.tick(today)
+                if self.event_dispatcher:
+                    for event in events:
+                        self.event_dispatcher.send_event(event, runner.context)
                 self.state_manager.save(runner, today)
                 print(f"[INFO] Field {field_id}: {len(events)} events on {today}")
             except Exception as e:

--- a/services/digizert_client.py
+++ b/services/digizert_client.py
@@ -1,0 +1,45 @@
+import httpx
+from models.planting_plan import FieldOperationEvent
+from models.sim_context import SimContext
+
+
+class DigiZertClient:
+    def __init__(
+        self,
+        api_url: str,
+        api_token: str,
+        timeout: int = 10
+    ) -> None:
+        self.api_url = api_url
+        self.api_token = api_token
+        self.timeout = timeout
+
+    def send_event(self, event: FieldOperationEvent, context: SimContext) -> None:
+        payload = self._build_payload(event, context)
+        headers = {
+            "Authorization": f"Token {self.api_token}",
+            "Content-Type": "application/json"
+        }
+        
+        response = httpx.post(
+            self.api_url,
+            json=payload,
+            headers=headers,
+            timeout=self.timeout
+        )
+        response.raise_for_status()
+
+    def _build_payload(self, event: FieldOperationEvent, context: SimContext) -> dict:
+        return {
+            "model": "pipeline.operation",
+            "pk": 0,
+            "fields": {
+                "field": event.field,
+                "worktype": event.worktype,
+                "start_date": event.start_date,
+                "end_date": event.end_date,
+                "area": event.area,
+                "fuel": event.fuel,
+                "worktype_text": event.worktype_text
+            }
+        }

--- a/tests/test_digizert_client.py
+++ b/tests/test_digizert_client.py
@@ -1,0 +1,218 @@
+import datetime
+from unittest.mock import Mock, patch
+import pytest
+import httpx
+
+from models.planting_plan import FieldOperationEvent
+from models.sim_context import SimContext
+from services.digizert_client import DigiZertClient
+
+
+@pytest.fixture
+def mock_event():
+    return FieldOperationEvent(
+        batch="test-batch",
+        field=123,
+        worktype=5,
+        exa_id=1,
+        start_date="2024-03-15",
+        end_date="2024-03-15",
+        area=10.5,
+        distance=100.0,
+        distanceWorked=95.0,
+        duration=2.5,
+        durationWorked=2.3,
+        fuel=15.5,
+        application_type="fertilizer",
+        application_category="nitrogen",
+        application_name="NPK",
+        application_amount=200.0,
+        application_unit="kg/ha",
+        worktype_text="Fertilization",
+        machine="Tractor XYZ"
+    )
+
+
+@pytest.fixture
+def mock_context():
+    return SimContext(
+        field_size=10.5,
+        soil_type="loam",
+        start_date=datetime.datetime(2024, 3, 1),
+        crop_type="Potato",
+        variety="Belana",
+        field_id=123,
+        field_name="Test Field",
+        fuel_variation=0.1
+    )
+
+
+def test_send_event_posts_correct_payload(mock_event, mock_context):
+    with patch('httpx.post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+        
+        client = DigiZertClient("http://test-api/", "test-token")
+        client.send_event(mock_event, mock_context)
+        
+        call_kwargs = mock_post.call_args
+        payload = call_kwargs.kwargs["json"]
+        
+        assert payload["model"] == "pipeline.operation"
+        assert payload["pk"] == 0
+        assert payload["fields"]["field"] == mock_event.field
+        assert payload["fields"]["worktype"] == mock_event.worktype
+        assert payload["fields"]["start_date"] == mock_event.start_date
+        assert payload["fields"]["end_date"] == mock_event.end_date
+        assert payload["fields"]["area"] == mock_event.area
+        assert payload["fields"]["fuel"] == mock_event.fuel
+        assert payload["fields"]["worktype_text"] == mock_event.worktype_text
+
+
+def test_send_event_sets_auth_header(mock_event, mock_context):
+    with patch('httpx.post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+        
+        client = DigiZertClient("http://test-api/", "my-secret-token")
+        client.send_event(mock_event, mock_context)
+        
+        headers = mock_post.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Token my-secret-token"
+        assert headers["Content-Type"] == "application/json"
+
+
+def test_send_event_uses_correct_url(mock_event, mock_context):
+    with patch('httpx.post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+        
+        client = DigiZertClient("http://test-api.com/operations/", "token")
+        client.send_event(mock_event, mock_context)
+        
+        call_args = mock_post.call_args
+        assert call_args.args[0] == "http://test-api.com/operations/"
+
+
+def test_send_event_uses_timeout(mock_event, mock_context):
+    with patch('httpx.post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.raise_for_status = Mock()
+        mock_post.return_value = mock_response
+        
+        client = DigiZertClient("http://test-api/", "token", timeout=15)
+        client.send_event(mock_event, mock_context)
+        
+        call_kwargs = mock_post.call_args.kwargs
+        assert call_kwargs["timeout"] == 15
+
+
+def test_send_event_raises_on_4xx(mock_event, mock_context):
+    with patch('httpx.post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status = Mock(
+            side_effect=httpx.HTTPStatusError(
+                "Not Found",
+                request=Mock(),
+                response=mock_response
+            )
+        )
+        mock_post.return_value = mock_response
+        
+        client = DigiZertClient("http://test-api/", "token")
+        with pytest.raises(httpx.HTTPStatusError):
+            client.send_event(mock_event, mock_context)
+
+
+def test_send_event_raises_on_5xx(mock_event, mock_context):
+    with patch('httpx.post') as mock_post:
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status = Mock(
+            side_effect=httpx.HTTPStatusError(
+                "Internal Server Error",
+                request=Mock(),
+                response=mock_response
+            )
+        )
+        mock_post.return_value = mock_response
+        
+        client = DigiZertClient("http://test-api/", "token")
+        with pytest.raises(httpx.HTTPStatusError):
+            client.send_event(mock_event, mock_context)
+
+
+def test_send_event_raises_on_timeout(mock_event, mock_context):
+    with patch('httpx.post', side_effect=httpx.TimeoutException("timeout")):
+        client = DigiZertClient("http://test-api/", "token")
+        with pytest.raises(httpx.TimeoutException):
+            client.send_event(mock_event, mock_context)
+
+
+def test_tick_scheduler_dispatches_events(mock_context):
+    from scheduler.tick_scheduler import TickScheduler
+    
+    mock_dispatcher = Mock()
+    
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
+        mock_runner = Mock()
+        event1 = FieldOperationEvent(field=1, worktype=1, start_date="2024-03-15")
+        event2 = FieldOperationEvent(field=1, worktype=2, start_date="2024-03-15")
+        mock_runner.tick.return_value = [event1, event2]
+        mock_runner.context = mock_context
+        MockRunner.return_value = mock_runner
+        
+        with patch('scheduler.tick_scheduler.StateManager'):
+            scheduler = TickScheduler([mock_context], event_dispatcher=mock_dispatcher)
+            scheduler.daily_tick()
+            
+            assert mock_dispatcher.send_event.call_count == 2
+            mock_dispatcher.send_event.assert_any_call(event1, mock_context)
+            mock_dispatcher.send_event.assert_any_call(event2, mock_context)
+
+
+def test_tick_scheduler_works_without_dispatcher(mock_context):
+    from scheduler.tick_scheduler import TickScheduler
+    
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
+        mock_runner = Mock()
+        mock_runner.tick.return_value = [
+            FieldOperationEvent(field=1, worktype=1, start_date="2024-03-15")
+        ]
+        mock_runner.context = mock_context
+        MockRunner.return_value = mock_runner
+        
+        with patch('scheduler.tick_scheduler.StateManager'):
+            scheduler = TickScheduler([mock_context])
+            
+            try:
+                scheduler.daily_tick()
+            except Exception as e:
+                pytest.fail(f"TickScheduler without dispatcher raised exception: {e}")
+
+
+def test_build_payload_structure(mock_event, mock_context):
+    client = DigiZertClient("http://test-api/", "token")
+    payload = client._build_payload(mock_event, mock_context)
+    
+    assert "model" in payload
+    assert "pk" in payload
+    assert "fields" in payload
+    assert isinstance(payload["fields"], dict)
+    
+    fields = payload["fields"]
+    assert "field" in fields
+    assert "worktype" in fields
+    assert "start_date" in fields
+    assert "end_date" in fields
+    assert "area" in fields
+    assert "fuel" in fields
+    assert "worktype_text" in fields


### PR DESCRIPTION
## Summary
Implements Issue #4 - DigiZertClient HTTP Event Dispatcher

This PR adds HTTP event dispatching functionality to send `FieldOperationEvent` data to the DigiZert API in real-time during simulation ticks.

## Changes

### New Components
- **`services/digizert_client.py`**: HTTP client for DigiZert API
  - `DigiZertClient` class with `send_event()` method
  - Sends events in `pipeline.operation` format
  - Token-based authentication
  - Configurable timeout (default: 10s)
  - Error handling for HTTP 4xx/5xx and timeouts

### Integration
- **`scheduler/tick_scheduler.py`**: 
  - Added optional `event_dispatcher` parameter to `__init__`
  - Integrated event dispatching in `daily_tick()` after `runner.tick()`
  - Maintains backward compatibility (works without dispatcher)

### Configuration
- **`.env.example`**: Template for API configuration
  - `DIGIZERT_API_URL`
  - `DIGIZERT_API_TOKEN`
  - `API_TIMEOUT_SECONDS`

### Dependencies
- **`pyproject.toml`**: Added `httpx>=0.27` (modern HTTP client with better timeout handling)

### Tests
- **`tests/test_digizert_client.py`**: 10 comprehensive tests
  1. Correct payload structure
  2. Authorization header
  3. Correct URL usage
  4. Timeout configuration
  5. HTTP 4xx error handling
  6. HTTP 5xx error handling
  7. Timeout exception handling
  8. TickScheduler event dispatching
  9. TickScheduler without dispatcher
  10. Payload structure validation

## Test Results
```
✅ 10/10 new tests passing
✅ 35/35 total tests passing (25 existing + 10 new)
```

## Architecture Decision
Event dispatching happens in `TickScheduler.daily_tick()` after `runner.tick()`, keeping `CalendarDrivenRunner` HTTP-agnostic as specified in the issue.

## Out of Scope (Future Issues)
- Retry logic with exponential backoff → Issue #5
- Structured logging → Issue #6

## Usage Example
```python
from services.digizert_client import DigiZertClient
from scheduler.tick_scheduler import TickScheduler

# Initialize client
client = DigiZertClient(
    api_url=os.environ["DIGIZERT_API_URL"],
    api_token=os.environ["DIGIZERT_API_TOKEN"],
    timeout=10
)

# Pass to scheduler
scheduler = TickScheduler(
    contexts=contexts,
    event_dispatcher=client
)
```

Closes #4