### PR TITLE
feat: Add RetryDispatcher with exponential backoff and queue (closes #5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 DIGIZERT_API_URL=https://api.digizert.example.com/operations/
 DIGIZERT_API_TOKEN=
 API_TIMEOUT_SECONDS=10
+RETRY_MAX_ATTEMPTS=3

--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,6 @@ simulation_events.json
 
 # State persistence
 state/
+
+# Retry queue
+retry_queue/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "requests>=2.26.0",
     "apscheduler>=3.10",
     "httpx>=0.27",
+    "tenacity>=8.2",
 ]
 
 [project.optional-dependencies]

--- a/services/retry_dispatcher.py
+++ b/services/retry_dispatcher.py
@@ -1,0 +1,155 @@
+import json
+import datetime
+from pathlib import Path
+from dataclasses import asdict
+from tenacity import retry, stop_after_attempt, wait_exponential, RetryError
+
+from models.planting_plan import FieldOperationEvent
+from models.sim_context import SimContext
+from services.digizert_client import DigiZertClient
+
+
+class RetryDispatcher:
+    def __init__(
+        self,
+        client: DigiZertClient,
+        max_attempts: int = 3,
+        queue_dir: str = "./retry_queue",
+        _wait_strategy=None
+    ) -> None:
+        self.client = client
+        self.max_attempts = max_attempts
+        self.queue_dir = Path(queue_dir)
+        self._wait = _wait_strategy or wait_exponential(multiplier=1, min=1, max=10)
+
+    def send_event(self, event: FieldOperationEvent, context: SimContext) -> None:
+        try:
+            self._send_with_retry(event, context)
+        except Exception as e:
+            print(f"[ERROR] All {self.max_attempts} attempts failed: {e}. Queuing event.")
+            self._save_to_queue(event, context)
+
+    def _send_with_retry(self, event: FieldOperationEvent, context: SimContext) -> None:
+        @retry(
+            stop=stop_after_attempt(self.max_attempts),
+            wait=self._wait,
+            reraise=True
+        )
+        def _attempt():
+            self.client.send_event(event, context)
+        
+        _attempt()
+
+    def process_queue(self) -> None:
+        if not self.queue_dir.exists():
+            return
+        
+        for queue_file in self.queue_dir.rglob("*.json"):
+            try:
+                with open(queue_file, 'r') as f:
+                    data = json.load(f)
+                
+                event = self._deserialize_event(data["event"])
+                context = self._deserialize_context(data["context"])
+                
+                try:
+                    self._send_with_retry(event, context)
+                    queue_file.unlink()
+                    print(f"[INFO] Successfully resent queued event from {queue_file}")
+                except Exception as e:
+                    print(f"[ERROR] Failed to resend queued event from {queue_file}: {e}")
+            except Exception as e:
+                print(f"[ERROR] Failed to process queue file {queue_file}: {e}")
+
+    def _save_to_queue(self, event: FieldOperationEvent, context: SimContext) -> None:
+        field_dir = self.queue_dir / str(context.field_id)
+        field_dir.mkdir(parents=True, exist_ok=True)
+        
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%dT%H%M%S")
+        queue_file = field_dir / f"{timestamp}.json"
+        
+        queue_data = {
+            "field_id": context.field_id,
+            "failed_at": datetime.datetime.now().isoformat(),
+            "event": self._serialize_event(event),
+            "context": self._serialize_context(context)
+        }
+        
+        with open(queue_file, 'w') as f:
+            json.dump(queue_data, f, indent=2)
+        
+        print(f"[INFO] Event queued to {queue_file}")
+
+    def _serialize_event(self, event: FieldOperationEvent) -> dict:
+        return {
+            "batch": event.batch,
+            "field": event.field,
+            "worktype": event.worktype,
+            "exa_id": event.exa_id,
+            "start_date": event.start_date,
+            "end_date": event.end_date,
+            "area": event.area,
+            "distance": event.distance,
+            "distanceWorked": event.distanceWorked,
+            "duration": event.duration,
+            "durationWorked": event.durationWorked,
+            "fuel": event.fuel,
+            "application_type": event.application_type,
+            "application_category": event.application_category,
+            "application_name": event.application_name,
+            "application_amount": event.application_amount,
+            "application_unit": event.application_unit,
+            "worktype_text": event.worktype_text,
+            "machine": event.machine
+        }
+
+    def _serialize_context(self, context: SimContext) -> dict:
+        return {
+            "field_size": context.field_size,
+            "soil_type": context.soil_type,
+            "start_date": context.start_date.isoformat() if isinstance(context.start_date, datetime.datetime) else context.start_date,
+            "crop_type": context.crop_type,
+            "variety": context.variety,
+            "field_id": context.field_id,
+            "field_name": context.field_name,
+            "fuel_variation": context.fuel_variation
+        }
+
+    def _deserialize_event(self, data: dict) -> FieldOperationEvent:
+        return FieldOperationEvent(
+            batch=data.get("batch"),
+            field=data.get("field"),
+            worktype=data.get("worktype"),
+            exa_id=data.get("exa_id"),
+            start_date=data.get("start_date"),
+            end_date=data.get("end_date"),
+            area=data.get("area"),
+            distance=data.get("distance"),
+            distanceWorked=data.get("distanceWorked"),
+            duration=data.get("duration"),
+            durationWorked=data.get("durationWorked"),
+            fuel=data.get("fuel"),
+            application_type=data.get("application_type"),
+            application_category=data.get("application_category"),
+            application_name=data.get("application_name"),
+            application_amount=data.get("application_amount"),
+            application_unit=data.get("application_unit"),
+            worktype_text=data.get("worktype_text"),
+            machine=data.get("machine")
+        )
+
+    def _deserialize_context(self, data: dict) -> SimContext:
+        start_date = data.get("start_date")
+        if isinstance(start_date, str):
+            start_date = datetime.datetime.fromisoformat(start_date)
+        
+        return SimContext(
+            field_size=data.get("field_size"),
+            soil_type=data.get("soil_type"),
+            start_date=start_date,
+            crop_type=data.get("crop_type"),
+            variety=data.get("variety"),
+            field_id=data.get("field_id"),
+            field_name=data.get("field_name"),
+            fuel_variation=data.get("fuel_variation")
+        )

--- a/services/retry_dispatcher.py
+++ b/services/retry_dispatcher.py
@@ -1,7 +1,6 @@
 import json
 import datetime
 from pathlib import Path
-from dataclasses import asdict
 from tenacity import retry, stop_after_attempt, wait_exponential, RetryError
 
 from models.planting_plan import FieldOperationEvent
@@ -30,10 +29,16 @@ class RetryDispatcher:
             self._save_to_queue(event, context)
 
     def _send_with_retry(self, event: FieldOperationEvent, context: SimContext) -> None:
+        def _log_retry(retry_state):
+            exception = retry_state.outcome.exception()
+            wait_time = self._wait(retry_state)
+            print(f"[WARN] Retry attempt {retry_state.attempt_number}/{self.max_attempts} after error: {exception}. Waiting {wait_time}s...")
+        
         @retry(
             stop=stop_after_attempt(self.max_attempts),
             wait=self._wait,
-            reraise=True
+            reraise=True,
+            before_sleep=_log_retry
         )
         def _attempt():
             self.client.send_event(event, context)

--- a/tests/test_retry_dispatcher.py
+++ b/tests/test_retry_dispatcher.py
@@ -41,6 +41,45 @@ def mock_context():
     )
 
 
+@pytest.fixture
+def queue_data(mock_event, mock_context):
+    return {
+        "field_id": 42,
+        "failed_at": "2024-03-15T08:30:05",
+        "event": {
+            "batch": mock_event.batch,
+            "field": mock_event.field,
+            "worktype": mock_event.worktype,
+            "exa_id": mock_event.exa_id,
+            "start_date": mock_event.start_date,
+            "end_date": mock_event.end_date,
+            "area": mock_event.area,
+            "distance": mock_event.distance,
+            "distanceWorked": mock_event.distanceWorked,
+            "duration": mock_event.duration,
+            "durationWorked": mock_event.durationWorked,
+            "fuel": mock_event.fuel,
+            "application_type": mock_event.application_type,
+            "application_category": mock_event.application_category,
+            "application_name": mock_event.application_name,
+            "application_amount": mock_event.application_amount,
+            "application_unit": mock_event.application_unit,
+            "worktype_text": mock_event.worktype_text,
+            "machine": mock_event.machine
+        },
+        "context": {
+            "field_size": mock_context.field_size,
+            "soil_type": mock_context.soil_type,
+            "start_date": mock_context.start_date.isoformat(),
+            "crop_type": mock_context.crop_type,
+            "variety": mock_context.variety,
+            "field_id": mock_context.field_id,
+            "field_name": mock_context.field_name,
+            "fuel_variation": mock_context.fuel_variation
+        }
+    }
+
+
 def make_fast_dispatcher(client, **kwargs):
     return RetryDispatcher(client, _wait_strategy=wait_none(), **kwargs)
 
@@ -142,45 +181,9 @@ def test_queue_file_stored_in_field_subdirectory(tmp_path, mock_event, mock_cont
     assert len(queue_files) == 1
 
 
-def test_process_queue_resends_events(tmp_path, mock_event, mock_context):
+def test_process_queue_resends_events(tmp_path, queue_data):
     field_dir = tmp_path / "42"
     field_dir.mkdir(parents=True)
-    
-    queue_data = {
-        "field_id": 42,
-        "failed_at": "2024-03-15T08:30:05",
-        "event": {
-            "batch": mock_event.batch,
-            "field": mock_event.field,
-            "worktype": mock_event.worktype,
-            "exa_id": mock_event.exa_id,
-            "start_date": mock_event.start_date,
-            "end_date": mock_event.end_date,
-            "area": mock_event.area,
-            "distance": mock_event.distance,
-            "distanceWorked": mock_event.distanceWorked,
-            "duration": mock_event.duration,
-            "durationWorked": mock_event.durationWorked,
-            "fuel": mock_event.fuel,
-            "application_type": mock_event.application_type,
-            "application_category": mock_event.application_category,
-            "application_name": mock_event.application_name,
-            "application_amount": mock_event.application_amount,
-            "application_unit": mock_event.application_unit,
-            "worktype_text": mock_event.worktype_text,
-            "machine": mock_event.machine
-        },
-        "context": {
-            "field_size": mock_context.field_size,
-            "soil_type": mock_context.soil_type,
-            "start_date": mock_context.start_date.isoformat(),
-            "crop_type": mock_context.crop_type,
-            "variety": mock_context.variety,
-            "field_id": mock_context.field_id,
-            "field_name": mock_context.field_name,
-            "fuel_variation": mock_context.fuel_variation
-        }
-    }
     
     queue_file = field_dir / "2024-03-15T083005.json"
     with open(queue_file, 'w') as f:
@@ -195,45 +198,9 @@ def test_process_queue_resends_events(tmp_path, mock_event, mock_context):
     assert mock_client.send_event.call_count == 1
 
 
-def test_process_queue_deletes_on_success(tmp_path, mock_event, mock_context):
+def test_process_queue_deletes_on_success(tmp_path, queue_data):
     field_dir = tmp_path / "42"
     field_dir.mkdir(parents=True)
-    
-    queue_data = {
-        "field_id": 42,
-        "failed_at": "2024-03-15T08:30:05",
-        "event": {
-            "batch": mock_event.batch,
-            "field": mock_event.field,
-            "worktype": mock_event.worktype,
-            "exa_id": mock_event.exa_id,
-            "start_date": mock_event.start_date,
-            "end_date": mock_event.end_date,
-            "area": mock_event.area,
-            "distance": mock_event.distance,
-            "distanceWorked": mock_event.distanceWorked,
-            "duration": mock_event.duration,
-            "durationWorked": mock_event.durationWorked,
-            "fuel": mock_event.fuel,
-            "application_type": mock_event.application_type,
-            "application_category": mock_event.application_category,
-            "application_name": mock_event.application_name,
-            "application_amount": mock_event.application_amount,
-            "application_unit": mock_event.application_unit,
-            "worktype_text": mock_event.worktype_text,
-            "machine": mock_event.machine
-        },
-        "context": {
-            "field_size": mock_context.field_size,
-            "soil_type": mock_context.soil_type,
-            "start_date": mock_context.start_date.isoformat(),
-            "crop_type": mock_context.crop_type,
-            "variety": mock_context.variety,
-            "field_id": mock_context.field_id,
-            "field_name": mock_context.field_name,
-            "fuel_variation": mock_context.fuel_variation
-        }
-    }
     
     queue_file = field_dir / "2024-03-15T083005.json"
     with open(queue_file, 'w') as f:
@@ -248,45 +215,9 @@ def test_process_queue_deletes_on_success(tmp_path, mock_event, mock_context):
     assert not queue_file.exists()
 
 
-def test_process_queue_keeps_file_on_failure(tmp_path, mock_event, mock_context):
+def test_process_queue_keeps_file_on_failure(tmp_path, queue_data):
     field_dir = tmp_path / "42"
     field_dir.mkdir(parents=True)
-    
-    queue_data = {
-        "field_id": 42,
-        "failed_at": "2024-03-15T08:30:05",
-        "event": {
-            "batch": mock_event.batch,
-            "field": mock_event.field,
-            "worktype": mock_event.worktype,
-            "exa_id": mock_event.exa_id,
-            "start_date": mock_event.start_date,
-            "end_date": mock_event.end_date,
-            "area": mock_event.area,
-            "distance": mock_event.distance,
-            "distanceWorked": mock_event.distanceWorked,
-            "duration": mock_event.duration,
-            "durationWorked": mock_event.durationWorked,
-            "fuel": mock_event.fuel,
-            "application_type": mock_event.application_type,
-            "application_category": mock_event.application_category,
-            "application_name": mock_event.application_name,
-            "application_amount": mock_event.application_amount,
-            "application_unit": mock_event.application_unit,
-            "worktype_text": mock_event.worktype_text,
-            "machine": mock_event.machine
-        },
-        "context": {
-            "field_size": mock_context.field_size,
-            "soil_type": mock_context.soil_type,
-            "start_date": mock_context.start_date.isoformat(),
-            "crop_type": mock_context.crop_type,
-            "variety": mock_context.variety,
-            "field_id": mock_context.field_id,
-            "field_name": mock_context.field_name,
-            "fuel_variation": mock_context.fuel_variation
-        }
-    }
     
     queue_file = field_dir / "2024-03-15T083005.json"
     with open(queue_file, 'w') as f:
@@ -313,45 +244,9 @@ def test_process_queue_empty_queue(tmp_path):
     mock_client.send_event.assert_not_called()
 
 
-def test_process_queue_handles_multiple_files(tmp_path, mock_event, mock_context):
+def test_process_queue_handles_multiple_files(tmp_path, queue_data):
     field_dir = tmp_path / "42"
     field_dir.mkdir(parents=True)
-    
-    queue_data = {
-        "field_id": 42,
-        "failed_at": "2024-03-15T08:30:05",
-        "event": {
-            "batch": mock_event.batch,
-            "field": mock_event.field,
-            "worktype": mock_event.worktype,
-            "exa_id": mock_event.exa_id,
-            "start_date": mock_event.start_date,
-            "end_date": mock_event.end_date,
-            "area": mock_event.area,
-            "distance": mock_event.distance,
-            "distanceWorked": mock_event.distanceWorked,
-            "duration": mock_event.duration,
-            "durationWorked": mock_event.durationWorked,
-            "fuel": mock_event.fuel,
-            "application_type": mock_event.application_type,
-            "application_category": mock_event.application_category,
-            "application_name": mock_event.application_name,
-            "application_amount": mock_event.application_amount,
-            "application_unit": mock_event.application_unit,
-            "worktype_text": mock_event.worktype_text,
-            "machine": mock_event.machine
-        },
-        "context": {
-            "field_size": mock_context.field_size,
-            "soil_type": mock_context.soil_type,
-            "start_date": mock_context.start_date.isoformat(),
-            "crop_type": mock_context.crop_type,
-            "variety": mock_context.variety,
-            "field_id": mock_context.field_id,
-            "field_name": mock_context.field_name,
-            "fuel_variation": mock_context.fuel_variation
-        }
-    }
     
     for i in range(3):
         queue_file = field_dir / f"2024-03-15T08300{i}.json"

--- a/tests/test_retry_dispatcher.py
+++ b/tests/test_retry_dispatcher.py
@@ -1,0 +1,369 @@
+import datetime
+import json
+from pathlib import Path
+from unittest.mock import Mock, patch
+import pytest
+import httpx
+from tenacity import wait_none
+
+from models.planting_plan import FieldOperationEvent
+from models.sim_context import SimContext
+from services.retry_dispatcher import RetryDispatcher
+from services.digizert_client import DigiZertClient
+
+
+@pytest.fixture
+def mock_event():
+    return FieldOperationEvent(
+        batch="test-batch",
+        field=42,
+        worktype=5,
+        exa_id=1,
+        start_date="2024-03-15",
+        end_date="2024-03-15",
+        area=10.5,
+        fuel=15.5,
+        worktype_text="Fertilization"
+    )
+
+
+@pytest.fixture
+def mock_context():
+    return SimContext(
+        field_size=10.5,
+        soil_type="loam",
+        start_date=datetime.datetime(2024, 3, 1),
+        crop_type="Potato",
+        variety="Belana",
+        field_id=42,
+        field_name="Nordfeld",
+        fuel_variation=0.1
+    )
+
+
+def make_fast_dispatcher(client, **kwargs):
+    return RetryDispatcher(client, _wait_strategy=wait_none(), **kwargs)
+
+
+def test_send_event_succeeds_on_first_attempt(tmp_path, mock_event, mock_context):
+    mock_client = Mock()
+    mock_client.send_event = Mock()
+    
+    dispatcher = make_fast_dispatcher(mock_client, queue_dir=str(tmp_path))
+    dispatcher.send_event(mock_event, mock_context)
+    
+    mock_client.send_event.assert_called_once_with(mock_event, mock_context)
+    queue_files = list(tmp_path.rglob("*.json"))
+    assert len(queue_files) == 0
+
+
+def test_send_event_queues_after_max_attempts(tmp_path, mock_event, mock_context):
+    mock_client = Mock()
+    mock_client.send_event.side_effect = httpx.TimeoutException("timeout")
+    
+    dispatcher = make_fast_dispatcher(mock_client, max_attempts=3, queue_dir=str(tmp_path))
+    dispatcher.send_event(mock_event, mock_context)
+    
+    assert mock_client.send_event.call_count == 3
+    queue_files = list(tmp_path.rglob("*.json"))
+    assert len(queue_files) == 1
+
+
+def test_send_event_succeeds_on_second_attempt(tmp_path, mock_event, mock_context):
+    mock_client = Mock()
+    mock_client.send_event.side_effect = [
+        httpx.TimeoutException("timeout"),
+        None
+    ]
+    
+    dispatcher = make_fast_dispatcher(mock_client, max_attempts=3, queue_dir=str(tmp_path))
+    dispatcher.send_event(mock_event, mock_context)
+    
+    assert mock_client.send_event.call_count == 2
+    queue_files = list(tmp_path.rglob("*.json"))
+    assert len(queue_files) == 0
+
+
+def test_send_event_succeeds_on_third_attempt(tmp_path, mock_event, mock_context):
+    mock_client = Mock()
+    mock_client.send_event.side_effect = [
+        httpx.TimeoutException("timeout"),
+        httpx.HTTPStatusError("Server Error", request=Mock(), response=Mock()),
+        None
+    ]
+    
+    dispatcher = make_fast_dispatcher(mock_client, max_attempts=3, queue_dir=str(tmp_path))
+    dispatcher.send_event(mock_event, mock_context)
+    
+    assert mock_client.send_event.call_count == 3
+    queue_files = list(tmp_path.rglob("*.json"))
+    assert len(queue_files) == 0
+
+
+def test_queue_file_contains_correct_format(tmp_path, mock_event, mock_context):
+    mock_client = Mock()
+    mock_client.send_event.side_effect = httpx.TimeoutException("timeout")
+    
+    dispatcher = make_fast_dispatcher(mock_client, max_attempts=3, queue_dir=str(tmp_path))
+    dispatcher.send_event(mock_event, mock_context)
+    
+    queue_files = list(tmp_path.rglob("*.json"))
+    assert len(queue_files) == 1
+    
+    with open(queue_files[0], 'r') as f:
+        data = json.load(f)
+    
+    assert "field_id" in data
+    assert data["field_id"] == 42
+    assert "failed_at" in data
+    assert "event" in data
+    assert "context" in data
+    
+    assert data["event"]["field"] == mock_event.field
+    assert data["event"]["worktype"] == mock_event.worktype
+    assert data["event"]["start_date"] == mock_event.start_date
+    
+    assert data["context"]["field_id"] == mock_context.field_id
+    assert data["context"]["field_name"] == mock_context.field_name
+
+
+def test_queue_file_stored_in_field_subdirectory(tmp_path, mock_event, mock_context):
+    mock_client = Mock()
+    mock_client.send_event.side_effect = httpx.TimeoutException("timeout")
+    
+    dispatcher = make_fast_dispatcher(mock_client, max_attempts=3, queue_dir=str(tmp_path))
+    dispatcher.send_event(mock_event, mock_context)
+    
+    field_dir = tmp_path / "42"
+    assert field_dir.exists()
+    assert field_dir.is_dir()
+    
+    queue_files = list(field_dir.glob("*.json"))
+    assert len(queue_files) == 1
+
+
+def test_process_queue_resends_events(tmp_path, mock_event, mock_context):
+    field_dir = tmp_path / "42"
+    field_dir.mkdir(parents=True)
+    
+    queue_data = {
+        "field_id": 42,
+        "failed_at": "2024-03-15T08:30:05",
+        "event": {
+            "batch": mock_event.batch,
+            "field": mock_event.field,
+            "worktype": mock_event.worktype,
+            "exa_id": mock_event.exa_id,
+            "start_date": mock_event.start_date,
+            "end_date": mock_event.end_date,
+            "area": mock_event.area,
+            "distance": mock_event.distance,
+            "distanceWorked": mock_event.distanceWorked,
+            "duration": mock_event.duration,
+            "durationWorked": mock_event.durationWorked,
+            "fuel": mock_event.fuel,
+            "application_type": mock_event.application_type,
+            "application_category": mock_event.application_category,
+            "application_name": mock_event.application_name,
+            "application_amount": mock_event.application_amount,
+            "application_unit": mock_event.application_unit,
+            "worktype_text": mock_event.worktype_text,
+            "machine": mock_event.machine
+        },
+        "context": {
+            "field_size": mock_context.field_size,
+            "soil_type": mock_context.soil_type,
+            "start_date": mock_context.start_date.isoformat(),
+            "crop_type": mock_context.crop_type,
+            "variety": mock_context.variety,
+            "field_id": mock_context.field_id,
+            "field_name": mock_context.field_name,
+            "fuel_variation": mock_context.fuel_variation
+        }
+    }
+    
+    queue_file = field_dir / "2024-03-15T083005.json"
+    with open(queue_file, 'w') as f:
+        json.dump(queue_data, f)
+    
+    mock_client = Mock()
+    mock_client.send_event = Mock()
+    
+    dispatcher = make_fast_dispatcher(mock_client, queue_dir=str(tmp_path))
+    dispatcher.process_queue()
+    
+    assert mock_client.send_event.call_count == 1
+
+
+def test_process_queue_deletes_on_success(tmp_path, mock_event, mock_context):
+    field_dir = tmp_path / "42"
+    field_dir.mkdir(parents=True)
+    
+    queue_data = {
+        "field_id": 42,
+        "failed_at": "2024-03-15T08:30:05",
+        "event": {
+            "batch": mock_event.batch,
+            "field": mock_event.field,
+            "worktype": mock_event.worktype,
+            "exa_id": mock_event.exa_id,
+            "start_date": mock_event.start_date,
+            "end_date": mock_event.end_date,
+            "area": mock_event.area,
+            "distance": mock_event.distance,
+            "distanceWorked": mock_event.distanceWorked,
+            "duration": mock_event.duration,
+            "durationWorked": mock_event.durationWorked,
+            "fuel": mock_event.fuel,
+            "application_type": mock_event.application_type,
+            "application_category": mock_event.application_category,
+            "application_name": mock_event.application_name,
+            "application_amount": mock_event.application_amount,
+            "application_unit": mock_event.application_unit,
+            "worktype_text": mock_event.worktype_text,
+            "machine": mock_event.machine
+        },
+        "context": {
+            "field_size": mock_context.field_size,
+            "soil_type": mock_context.soil_type,
+            "start_date": mock_context.start_date.isoformat(),
+            "crop_type": mock_context.crop_type,
+            "variety": mock_context.variety,
+            "field_id": mock_context.field_id,
+            "field_name": mock_context.field_name,
+            "fuel_variation": mock_context.fuel_variation
+        }
+    }
+    
+    queue_file = field_dir / "2024-03-15T083005.json"
+    with open(queue_file, 'w') as f:
+        json.dump(queue_data, f)
+    
+    mock_client = Mock()
+    mock_client.send_event = Mock()
+    
+    dispatcher = make_fast_dispatcher(mock_client, queue_dir=str(tmp_path))
+    dispatcher.process_queue()
+    
+    assert not queue_file.exists()
+
+
+def test_process_queue_keeps_file_on_failure(tmp_path, mock_event, mock_context):
+    field_dir = tmp_path / "42"
+    field_dir.mkdir(parents=True)
+    
+    queue_data = {
+        "field_id": 42,
+        "failed_at": "2024-03-15T08:30:05",
+        "event": {
+            "batch": mock_event.batch,
+            "field": mock_event.field,
+            "worktype": mock_event.worktype,
+            "exa_id": mock_event.exa_id,
+            "start_date": mock_event.start_date,
+            "end_date": mock_event.end_date,
+            "area": mock_event.area,
+            "distance": mock_event.distance,
+            "distanceWorked": mock_event.distanceWorked,
+            "duration": mock_event.duration,
+            "durationWorked": mock_event.durationWorked,
+            "fuel": mock_event.fuel,
+            "application_type": mock_event.application_type,
+            "application_category": mock_event.application_category,
+            "application_name": mock_event.application_name,
+            "application_amount": mock_event.application_amount,
+            "application_unit": mock_event.application_unit,
+            "worktype_text": mock_event.worktype_text,
+            "machine": mock_event.machine
+        },
+        "context": {
+            "field_size": mock_context.field_size,
+            "soil_type": mock_context.soil_type,
+            "start_date": mock_context.start_date.isoformat(),
+            "crop_type": mock_context.crop_type,
+            "variety": mock_context.variety,
+            "field_id": mock_context.field_id,
+            "field_name": mock_context.field_name,
+            "fuel_variation": mock_context.fuel_variation
+        }
+    }
+    
+    queue_file = field_dir / "2024-03-15T083005.json"
+    with open(queue_file, 'w') as f:
+        json.dump(queue_data, f)
+    
+    mock_client = Mock()
+    mock_client.send_event.side_effect = httpx.TimeoutException("timeout")
+    
+    dispatcher = make_fast_dispatcher(mock_client, max_attempts=3, queue_dir=str(tmp_path))
+    dispatcher.process_queue()
+    
+    assert queue_file.exists()
+
+
+def test_process_queue_empty_queue(tmp_path):
+    mock_client = Mock()
+    dispatcher = make_fast_dispatcher(mock_client, queue_dir=str(tmp_path))
+    
+    try:
+        dispatcher.process_queue()
+    except Exception as e:
+        pytest.fail(f"process_queue() raised exception on empty queue: {e}")
+    
+    mock_client.send_event.assert_not_called()
+
+
+def test_process_queue_handles_multiple_files(tmp_path, mock_event, mock_context):
+    field_dir = tmp_path / "42"
+    field_dir.mkdir(parents=True)
+    
+    queue_data = {
+        "field_id": 42,
+        "failed_at": "2024-03-15T08:30:05",
+        "event": {
+            "batch": mock_event.batch,
+            "field": mock_event.field,
+            "worktype": mock_event.worktype,
+            "exa_id": mock_event.exa_id,
+            "start_date": mock_event.start_date,
+            "end_date": mock_event.end_date,
+            "area": mock_event.area,
+            "distance": mock_event.distance,
+            "distanceWorked": mock_event.distanceWorked,
+            "duration": mock_event.duration,
+            "durationWorked": mock_event.durationWorked,
+            "fuel": mock_event.fuel,
+            "application_type": mock_event.application_type,
+            "application_category": mock_event.application_category,
+            "application_name": mock_event.application_name,
+            "application_amount": mock_event.application_amount,
+            "application_unit": mock_event.application_unit,
+            "worktype_text": mock_event.worktype_text,
+            "machine": mock_event.machine
+        },
+        "context": {
+            "field_size": mock_context.field_size,
+            "soil_type": mock_context.soil_type,
+            "start_date": mock_context.start_date.isoformat(),
+            "crop_type": mock_context.crop_type,
+            "variety": mock_context.variety,
+            "field_id": mock_context.field_id,
+            "field_name": mock_context.field_name,
+            "fuel_variation": mock_context.fuel_variation
+        }
+    }
+    
+    for i in range(3):
+        queue_file = field_dir / f"2024-03-15T08300{i}.json"
+        with open(queue_file, 'w') as f:
+            json.dump(queue_data, f)
+    
+    mock_client = Mock()
+    mock_client.send_event = Mock()
+    
+    dispatcher = make_fast_dispatcher(mock_client, queue_dir=str(tmp_path))
+    dispatcher.process_queue()
+    
+    assert mock_client.send_event.call_count == 3
+    queue_files = list(field_dir.glob("*.json"))
+    assert len(queue_files) == 0


### PR DESCRIPTION
## Summary
Implements Issue #5 - Retry-Mechanismus mit exponentiellem Backoff

This PR adds a retry mechanism with exponential backoff and persistent queue for failed HTTP events, wrapping the DigiZertClient in a transparent drop-in replacement.

## Changes

### New Components
- **`services/retry_dispatcher.py`**: Retry wrapper for DigiZertClient
  - `RetryDispatcher` class implementing same interface as `DigiZertClient`
  - Exponential backoff retry using `tenacity` library
  - Configurable max attempts (default: 3)
  - Persistent queue for failed events in `retry_queue/<field_id>/`
  - `process_queue()` method to resend queued events on startup
  - Automatic serialization/deserialization of events and contexts

### Configuration
- **`.env.example`**: Added `RETRY_MAX_ATTEMPTS=3`
- **`.gitignore`**: Added `retry_queue/` directory

### Dependencies
- **`pyproject.toml`**: Added `tenacity>=8.2` for retry logic

### Tests
- **`tests/test_retry_dispatcher.py`**: 11 comprehensive tests
  1. Success on first attempt (no retry, no queue)
  2. Queue after max attempts exhausted
  3. Success on second attempt (retry works)
  4. Success on third attempt (multiple retries)
  5. Queue file contains correct JSON format
  6. Queue file stored in field subdirectory
  7. `process_queue()` resends events
  8. `process_queue()` deletes on success
  9. `process_queue()` keeps file on failure
  10. `process_queue()` handles empty queue
  11. `process_queue()` handles multiple files

**All tests use `wait_none()` for fast execution without real sleep times.**

## Test Results
```
✅ 11/11 new tests passing
✅ 46/46 total tests passing (35 existing + 11 new)
```

## Architecture

### Drop-in Replacement
`RetryDispatcher` implements the same `send_event(event, context)` interface as `DigiZertClient`, making it a transparent wrapper:

```python
# Before (direct client)
client = DigiZertClient(api_url, api_token)
scheduler = TickScheduler(contexts, event_dispatcher=client)

# After (with retry)
client = DigiZertClient(api_url, api_token)
dispatcher = RetryDispatcher(client, max_attempts=3)
dispatcher.process_queue()  # resend queued events
scheduler = TickScheduler(contexts, event_dispatcher=dispatcher)
```

### Retry Logic
- Uses `tenacity` library for robust retry mechanism
- Exponential backoff: 1s, 2s, 4s, 8s, 10s (max)
- Retries on all exceptions (HTTP 4xx/5xx, timeouts, network errors)
- After max attempts: event saved to persistent queue

### Queue Format
Events are stored in `retry_queue/<field_id>/<timestamp>.json`:
```json
{
  "field_id": 42,
  "failed_at": "2024-03-15T08:30:05",
  "event": { ... },
  "context": { ... }
}
```

### Startup Flow
```python
dispatcher = RetryDispatcher(client)
dispatcher.process_queue()  # ← Process queued events before starting
scheduler = TickScheduler(contexts, event_dispatcher=dispatcher)
scheduler.start()
```

## Out of Scope (Future Issues)
- Structured logging with `logging` module → Issue #6
- Queue processing as background thread → Issue #7

## Usage Example
```python
import os
from dotenv import load_dotenv
from services.digizert_client import DigiZertClient
from services.retry_dispatcher import RetryDispatcher
from scheduler.tick_scheduler import TickScheduler

load_dotenv()

# Initialize client
client = DigiZertClient(
    api_url=os.environ["DIGIZERT_API_URL"],
    api_token=os.environ["DIGIZERT_API_TOKEN"],
    timeout=int(os.getenv("API_TIMEOUT_SECONDS", "10"))
)

# Wrap with retry dispatcher
dispatcher = RetryDispatcher(
    client,
    max_attempts=int(os.getenv("RETRY_MAX_ATTEMPTS", "3"))
)

# Process any queued events from previous failures
dispatcher.process_queue()

# Pass to scheduler
scheduler = TickScheduler(contexts, event_dispatcher=dispatcher)
scheduler.start()
```

Closes #5