### PR TITLE
feat: Add parallel field processing with asyncio (closes #10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ FARM_ID=7
 
 # Scheduler Configuration
 TICK_TIME=06:00
+MAX_CONCURRENT_FIELDS=10
 
 # Storage Configuration
 STATE_DIR=./state

--- a/config/settings.py
+++ b/config/settings.py
@@ -25,6 +25,7 @@ class DaemonConfig:
     season_start_date: datetime.datetime
     fuel_variation: float
     farms_config_path: str
+    max_concurrent_fields: int
 
 
 def load_and_validate_config() -> DaemonConfig:
@@ -58,6 +59,7 @@ def load_and_validate_config() -> DaemonConfig:
         ),
         fuel_variation=float(os.getenv("FUEL_VARIATION", "0.1")),
         farms_config_path=os.getenv("FARMS_CONFIG_PATH", "./config/farms.json"),
+        max_concurrent_fields=int(os.getenv("MAX_CONCURRENT_FIELDS", "10")),
     )
 
 

--- a/daemon.py
+++ b/daemon.py
@@ -47,6 +47,7 @@ def main() -> None:
         tick_time=config.tick_time,
         state_dir=config.state_dir,
         event_dispatcher=dispatcher,
+        max_concurrent_fields=config.max_concurrent_fields,
     )
 
     def _shutdown(signum, frame):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ exclude = ["config*", "export*", "tests*", "documentation*"]
 [dependency-groups]
 dev = [
     "pytest>=9.0.2",
+    "pytest-asyncio>=0.23.0",
     "pyyaml>=6.0",
 ]
 

--- a/scheduler/tick_scheduler.py
+++ b/scheduler/tick_scheduler.py
@@ -1,3 +1,4 @@
+import asyncio
 import datetime
 import time
 from typing import List
@@ -14,11 +15,19 @@ logger = get_logger("tick_scheduler")
 
 
 class TickScheduler:
-    def __init__(self, contexts: List[SimContext], tick_time: str = "06:00", state_dir: str = "./state", event_dispatcher=None) -> None:
+    def __init__(
+        self,
+        contexts: List[SimContext],
+        tick_time: str = "06:00",
+        state_dir: str = "./state",
+        event_dispatcher=None,
+        max_concurrent_fields: int = 10
+    ) -> None:
         self.contexts = contexts
         self.tick_time = tick_time
         self.state_manager = StateManager(state_dir)
         self.event_dispatcher = event_dispatcher
+        self.max_concurrent_fields = max_concurrent_fields
         
         self.tick_hour, self.tick_minute = self._parse_tick_time(tick_time)
         
@@ -33,7 +42,7 @@ class TickScheduler:
         
         self.scheduler = BackgroundScheduler()
         self.scheduler.add_job(
-            self.daily_tick,
+            self._daily_tick_sync,
             CronTrigger(hour=self.tick_hour, minute=self.tick_minute),
             id='daily_tick'
         )
@@ -46,23 +55,45 @@ class TickScheduler:
         minute = int(parts[1])
         return hour, minute
     
-    def daily_tick(self) -> None:
+    def _daily_tick_sync(self) -> None:
+        asyncio.run(self.daily_tick())
+    
+    async def daily_tick(self) -> None:
         today = datetime.date.today()
-        for field_id, runner in self.runners.items():
-            try:
-                events = runner.tick(today)
-                if self.event_dispatcher:
-                    for event in events:
-                        self.event_dispatcher.send_event(event, runner.context)
-                self.state_manager.save(runner, today)
-                logger.info("Tick completed", field_id=field_id, events_sent=len(events), tick_date=str(today))
-            except Exception as e:
-                logger.error("Tick failed", field_id=field_id, error=str(e))
+        
+        semaphore = asyncio.Semaphore(self.max_concurrent_fields)
+        
+        async def process_field(field_id: int, runner: CalendarDrivenRunner):
+            async with semaphore:
+                try:
+                    events = await asyncio.to_thread(runner.tick, today)
+                    
+                    if self.event_dispatcher:
+                        for event in events:
+                            await asyncio.to_thread(
+                                self.event_dispatcher.send_event,
+                                event,
+                                runner.context
+                            )
+                    
+                    await asyncio.to_thread(self.state_manager.save, runner, today)
+                    logger.info("Tick completed", field_id=field_id, events_sent=len(events), tick_date=str(today))
+                    return {"field_id": field_id, "success": True, "events": len(events)}
+                except Exception as e:
+                    logger.error("Tick failed", field_id=field_id, error=str(e))
+                    return {"field_id": field_id, "success": False, "error": str(e)}
+        
+        tasks = [process_field(fid, runner) for fid, runner in self.runners.items()]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        
+        successful = sum(1 for r in results if isinstance(r, dict) and r.get("success"))
+        total = len(results)
+        logger.info("Tick summary", successful=successful, total=total, tick_date=str(today))
     
     def start(self) -> None:
         self.scheduler.start()
         self._running = True
-        logger.info("TickScheduler started", field_count=len(self.runners), tick_time=self.tick_time)
+        logger.info("TickScheduler started", field_count=len(self.runners), tick_time=self.tick_time, max_concurrent=self.max_concurrent_fields)
         
         try:
             while self._running:

--- a/tests/test_config_settings.py
+++ b/tests/test_config_settings.py
@@ -103,7 +103,8 @@ def test_load_sim_contexts_returns_correct_count(monkeypatch, tmp_path):
         variety="Belana",
         season_start_date=datetime.datetime(2024, 10, 1),
         fuel_variation=0.1,
-        farms_config_path=str(farms_file)
+        farms_config_path=str(farms_file),
+        max_concurrent_fields=10
     )
     
     contexts = load_sim_contexts(config)
@@ -141,7 +142,8 @@ def test_load_sim_contexts_unknown_farm_raises(monkeypatch, tmp_path):
         variety="Belana",
         season_start_date=datetime.datetime(2024, 10, 1),
         fuel_variation=0.1,
-        farms_config_path=str(farms_file)
+        farms_config_path=str(farms_file),
+        max_concurrent_fields=10
     )
     
     with pytest.raises(ValueError, match="Farm ID 99 not found"):
@@ -183,7 +185,8 @@ def test_load_sim_contexts_maps_fields_correctly(tmp_path):
         variety="Spelt",
         season_start_date=datetime.datetime(2024, 11, 1),
         fuel_variation=0.2,
-        farms_config_path=str(farms_file)
+        farms_config_path=str(farms_file),
+        max_concurrent_fields=10
     )
     
     contexts = load_sim_contexts(config)
@@ -336,7 +339,8 @@ def test_load_sim_contexts_with_multiple_farms_selects_correct_one(tmp_path):
         variety="Belana",
         season_start_date=datetime.datetime(2024, 10, 1),
         fuel_variation=0.1,
-        farms_config_path=str(farms_file)
+        farms_config_path=str(farms_file),
+        max_concurrent_fields=10
     )
     
     contexts = load_sim_contexts(config)

--- a/tests/test_digizert_client.py
+++ b/tests/test_digizert_client.py
@@ -158,6 +158,7 @@ def test_send_event_raises_on_timeout(mock_event, mock_context):
 
 
 def test_tick_scheduler_dispatches_events(mock_context):
+    import asyncio
     from scheduler.tick_scheduler import TickScheduler
     
     mock_dispatcher = Mock()
@@ -172,7 +173,7 @@ def test_tick_scheduler_dispatches_events(mock_context):
         
         with patch('scheduler.tick_scheduler.StateManager'):
             scheduler = TickScheduler([mock_context], event_dispatcher=mock_dispatcher)
-            scheduler.daily_tick()
+            asyncio.run(scheduler.daily_tick())
             
             assert mock_dispatcher.send_event.call_count == 2
             mock_dispatcher.send_event.assert_any_call(event1, mock_context)
@@ -180,6 +181,7 @@ def test_tick_scheduler_dispatches_events(mock_context):
 
 
 def test_tick_scheduler_works_without_dispatcher(mock_context):
+    import asyncio
     from scheduler.tick_scheduler import TickScheduler
     
     with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
@@ -194,7 +196,7 @@ def test_tick_scheduler_works_without_dispatcher(mock_context):
             scheduler = TickScheduler([mock_context])
             
             try:
-                scheduler.daily_tick()
+                asyncio.run(scheduler.daily_tick())
             except Exception as e:
                 pytest.fail(f"TickScheduler without dispatcher raised exception: {e}")
 

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -42,6 +42,7 @@ def mock_context():
 
 
 def test_tick_scheduler_logs_tick_completed(mock_context):
+    import asyncio
     with structlog.testing.capture_logs() as logs:
         with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
             mock_runner = Mock()
@@ -51,7 +52,7 @@ def test_tick_scheduler_logs_tick_completed(mock_context):
             
             with patch('scheduler.tick_scheduler.StateManager'):
                 scheduler = TickScheduler([mock_context])
-                scheduler.daily_tick()
+                asyncio.run(scheduler.daily_tick())
     
     tick_logs = [l for l in logs if l.get("event") == "Tick completed"]
     assert len(tick_logs) == 1
@@ -82,6 +83,7 @@ def test_tick_scheduler_logs_state_restored(mock_context):
 
 
 def test_tick_scheduler_logs_tick_failed(mock_context):
+    import asyncio
     with structlog.testing.capture_logs() as logs:
         with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
             mock_runner = Mock()
@@ -91,7 +93,7 @@ def test_tick_scheduler_logs_tick_failed(mock_context):
             
             with patch('scheduler.tick_scheduler.StateManager'):
                 scheduler = TickScheduler([mock_context])
-                scheduler.daily_tick()
+                asyncio.run(scheduler.daily_tick())
     
     error_logs = [l for l in logs if l.get("event") == "Tick failed"]
     assert len(error_logs) == 1

--- a/tests/test_parallel_tick.py
+++ b/tests/test_parallel_tick.py
@@ -1,0 +1,162 @@
+import pytest
+import asyncio
+import datetime
+from unittest.mock import Mock, patch
+from pathlib import Path
+
+from scheduler.tick_scheduler import TickScheduler
+from models.sim_context import SimContext
+
+
+@pytest.fixture
+def multiple_contexts():
+    return [
+        SimContext(
+            field_id=i,
+            field_name=f"Field {i}",
+            field_size=10.0,
+            soil_type="sand",
+            start_date=datetime.datetime(2024, 10, 1),
+            crop_type="Potato",
+            variety="Belana",
+            fuel_variation=0.1
+        )
+        for i in range(1, 6)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_daily_tick_processes_all_fields(tmp_path, multiple_contexts):
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
+        mock_runners = {}
+        for ctx in multiple_contexts:
+            mock_runner = Mock()
+            mock_runner.tick.return_value = []
+            mock_runner.context = ctx
+            mock_runners[ctx.field_id] = mock_runner
+        
+        MockRunner.side_effect = lambda ctx: mock_runners[ctx.field_id]
+        
+        scheduler = TickScheduler(multiple_contexts, state_dir=str(tmp_path))
+        await scheduler.daily_tick()
+        
+        for runner in mock_runners.values():
+            runner.tick.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_field_error_does_not_stop_others(tmp_path, multiple_contexts):
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
+        mock_runners = {}
+        for i, ctx in enumerate(multiple_contexts):
+            mock_runner = Mock()
+            if i == 2:
+                mock_runner.tick.side_effect = Exception("Field 3 error")
+            else:
+                mock_runner.tick.return_value = []
+            mock_runner.context = ctx
+            mock_runners[ctx.field_id] = mock_runner
+        
+        MockRunner.side_effect = lambda ctx: mock_runners[ctx.field_id]
+        
+        scheduler = TickScheduler(multiple_contexts, state_dir=str(tmp_path))
+        await scheduler.daily_tick()
+        
+        for runner in mock_runners.values():
+            assert runner.tick.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_max_concurrent_fields_limits_parallelism(tmp_path):
+    contexts = [
+        SimContext(
+            field_id=i,
+            field_name=f"Field {i}",
+            field_size=10.0,
+            soil_type="sand",
+            start_date=datetime.datetime(2024, 10, 1),
+            crop_type="Potato",
+            variety="Belana",
+            fuel_variation=0.1
+        )
+        for i in range(1, 21)
+    ]
+    
+    concurrent_count = 0
+    max_concurrent = 0
+    lock = asyncio.Lock()
+    
+    def slow_tick(*args):
+        import time
+        nonlocal concurrent_count, max_concurrent
+        concurrent_count += 1
+        max_concurrent = max(max_concurrent, concurrent_count)
+        time.sleep(0.01)
+        concurrent_count -= 1
+        return []
+    
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
+        mock_runners = {}
+        for ctx in contexts:
+            mock_runner = Mock()
+            mock_runner.tick = slow_tick
+            mock_runner.context = ctx
+            mock_runners[ctx.field_id] = mock_runner
+        
+        MockRunner.side_effect = lambda ctx: mock_runners[ctx.field_id]
+        
+        scheduler = TickScheduler(contexts, state_dir=str(tmp_path), max_concurrent_fields=5)
+        await scheduler.daily_tick()
+        
+        assert max_concurrent <= 5
+
+
+def test_tick_scheduler_accepts_max_concurrent_fields(tmp_path):
+    context = SimContext(
+        field_id=1,
+        field_name="Test",
+        field_size=10.0,
+        soil_type="sand",
+        start_date=datetime.datetime(2024, 10, 1),
+        crop_type="Potato",
+        variety="Belana",
+        fuel_variation=0.1
+    )
+    
+    with patch('scheduler.tick_scheduler.CalendarDrivenRunner'):
+        scheduler = TickScheduler([context], state_dir=str(tmp_path), max_concurrent_fields=15)
+        assert scheduler.max_concurrent_fields == 15
+
+
+@pytest.mark.asyncio
+async def test_tick_summary_logs_success_count(tmp_path, multiple_contexts, caplog):
+    import structlog.testing
+    
+    with structlog.testing.capture_logs() as logs:
+        with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner, \
+             patch('scheduler.tick_scheduler.StateManager') as MockStateManager:
+            
+            mock_state_manager = Mock()
+            mock_state_manager.load.return_value = None
+            mock_state_manager.save.return_value = None
+            MockStateManager.return_value = mock_state_manager
+            
+            mock_runners = {}
+            for i, ctx in enumerate(multiple_contexts):
+                mock_runner = Mock()
+                if i < 3:
+                    mock_runner.tick.return_value = []
+                else:
+                    mock_runner.tick.side_effect = Exception("error")
+                mock_runner.context = ctx
+                mock_runners[ctx.field_id] = mock_runner
+            
+            MockRunner.side_effect = lambda ctx: mock_runners[ctx.field_id]
+            
+            scheduler = TickScheduler(multiple_contexts, state_dir=str(tmp_path))
+            await scheduler.daily_tick()
+    
+    summary_logs = [l for l in logs if l.get("event") == "Tick summary"]
+    assert len(summary_logs) == 1
+    assert summary_logs[0]["successful"] == 3
+    assert summary_logs[0]["total"] == 5

--- a/tests/test_parallel_tick.py
+++ b/tests/test_parallel_tick.py
@@ -84,15 +84,18 @@ async def test_max_concurrent_fields_limits_parallelism(tmp_path):
     
     concurrent_count = 0
     max_concurrent = 0
-    lock = asyncio.Lock()
+    import threading
+    lock = threading.Lock()
     
     def slow_tick(*args):
         import time
         nonlocal concurrent_count, max_concurrent
-        concurrent_count += 1
-        max_concurrent = max(max_concurrent, concurrent_count)
+        with lock:
+            concurrent_count += 1
+            max_concurrent = max(max_concurrent, concurrent_count)
         time.sleep(0.01)
-        concurrent_count -= 1
+        with lock:
+            concurrent_count -= 1
         return []
     
     with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:

--- a/tests/test_tick_scheduler.py
+++ b/tests/test_tick_scheduler.py
@@ -34,8 +34,9 @@ def sample_contexts():
 
 def test_daily_tick_calls_tick_for_each_field(sample_contexts):
     """
-    Test 1: daily_tick() ruft tick(today) für jedes Feld auf
+    Test 1: daily_tick ruft tick() für jedes Feld auf
     """
+    import asyncio
     with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
         mock_runner_1 = Mock()
         mock_runner_1.tick.return_value = []
@@ -49,7 +50,7 @@ def test_daily_tick_calls_tick_for_each_field(sample_contexts):
         with patch('scheduler.tick_scheduler.datetime') as mock_datetime:
             mock_datetime.date.today.return_value = datetime.date(2024, 11, 15)
             
-            scheduler.daily_tick()
+            asyncio.run(scheduler.daily_tick())
             
             mock_runner_1.tick.assert_called_once_with(datetime.date(2024, 11, 15))
             mock_runner_2.tick.assert_called_once_with(datetime.date(2024, 11, 15))
@@ -59,6 +60,7 @@ def test_daily_tick_field_error_does_not_stop_others(sample_contexts):
     """
     Test 2: Fehler in einem Feld stoppt nicht andere Felder
     """
+    import asyncio
     with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
         mock_runner_1 = Mock()
         mock_runner_1.tick.side_effect = Exception("Field 1 error")
@@ -72,7 +74,7 @@ def test_daily_tick_field_error_does_not_stop_others(sample_contexts):
         with patch('scheduler.tick_scheduler.datetime') as mock_datetime:
             mock_datetime.date.today.return_value = datetime.date(2024, 11, 15)
             
-            scheduler.daily_tick()
+            asyncio.run(scheduler.daily_tick())
             
             mock_runner_1.tick.assert_called_once()
             mock_runner_2.tick.assert_called_once()
@@ -96,6 +98,7 @@ def test_daily_tick_passes_today_to_runners(sample_contexts):
     """
     Test 4: daily_tick() übergibt datetime.date.today() an jeden Runner
     """
+    import asyncio
     with patch('scheduler.tick_scheduler.CalendarDrivenRunner') as MockRunner:
         mock_runner = Mock()
         mock_runner.tick.return_value = []
@@ -107,7 +110,7 @@ def test_daily_tick_passes_today_to_runners(sample_contexts):
             test_date = datetime.date(2024, 12, 25)
             mock_datetime.date.today.return_value = test_date
             
-            scheduler.daily_tick()
+            asyncio.run(scheduler.daily_tick())
             
             for call_args in mock_runner.tick.call_args_list:
                 assert call_args[0][0] == test_date


### PR DESCRIPTION
## Milestone 4 – Multi-Feld-Parallelität

This PR implements parallel field processing using `asyncio` to significantly improve tick performance for farms with many fields.

### Changes

**Core Implementation:**
- ✅ Implemented async `daily_tick()` with `asyncio.gather()` for parallel field processing
- ✅ Added `Semaphore(max_concurrent_fields)` to limit parallelism (default: 10)
- ✅ Added `_daily_tick_sync()` wrapper for APScheduler compatibility
- ✅ Error isolation with `return_exceptions=True` in `asyncio.gather()`
- ✅ Tick summary logging with `successful` and `total` field counts

**Configuration:**
- ✅ Added `max_concurrent_fields` parameter to `DaemonConfig`
- ✅ Added `MAX_CONCURRENT_FIELDS=10` to `.env.example`
- ✅ Updated `daemon.py` to pass `max_concurrent_fields` to `TickScheduler`

**Testing:**
- ✅ Added `pytest-asyncio>=0.23.0` to dev dependencies
- ✅ Created `tests/test_parallel_tick.py` with 5 comprehensive async tests:
  1. `test_daily_tick_processes_all_fields` - Verifies all fields are processed
  2. `test_field_error_does_not_stop_others` - Error isolation works correctly
  3. `test_max_concurrent_fields_limits_parallelism` - Semaphore limits concurrency
  4. `test_tick_scheduler_accepts_max_concurrent_fields` - Parameter acceptance
  5. `test_tick_summary_logs_success_count` - Logging summary is correct
- ✅ Updated all existing tests to handle async `daily_tick()` method

### Test Results
```
80 passed, 4 skipped in 1.32s
```
- 75 existing tests (all passing)
- 5 new parallel processing tests (all passing)

### Architecture Decision: `asyncio` vs `ThreadPoolExecutor`

Chose `asyncio` because:
- DigiSim is I/O-bound (API calls, file I/O for state)
- Better error isolation with `return_exceptions=True`
- Minimal changes to existing sync code via `asyncio.to_thread()`

### Performance Impact

For a farm with 50 fields:
- **Before:** Sequential processing (~50 × tick_time)
- **After:** Parallel processing with max 10 concurrent (~5 × tick_time)
- **Expected improvement:** ~10x faster tick processing

### Definition of Done
- [x] `scheduler/tick_scheduler.py` with async `daily_tick()` and `asyncio.gather()`
- [x] `_daily_tick_sync()` as sync wrapper for APScheduler
- [x] `Semaphore(max_concurrent_fields)` limits parallelity
- [x] `config/settings.py` has `max_concurrent_fields` field
- [x] `.env.example` includes `MAX_CONCURRENT_FIELDS=10`
- [x] `daemon.py` passes `config.max_concurrent_fields`
- [x] `tests/test_parallel_tick.py` with 5 async tests
- [x] `pytest-asyncio` added to dev dependencies
- [x] All 80 tests passing (75 existing + 5 new)
- [x] Tick summary logs `successful` and `total` counts

Closes #10