### PR TITLE
fix: DigiZert API integration - field IDs, auth header, pagination

### DIFF
--- a/.windsurf/rules/styleguide.md
+++ b/.windsurf/rules/styleguide.md
@@ -1,0 +1,46 @@
+---
+trigger: model_decision
+description: integration of new features should follow event-driven core principle
+---
+Handreichung für Entwickler: Event-Driven Core in DigiSim
+Warum dieses Prinzip?
+DigiSim entwickelt sich in Richtung einer nachvollziehbaren, erweiterbaren und analysierbaren Simulationsarchitektur.
+Damit fachliche Logik, Zustandsänderungen und externe Integration nicht zu stark miteinander vermischt werden, sollen neue Features möglichst nach einem einfachen Event-Driven-Core-Prinzip umgesetzt werden.
+Architekturregel
+Wenn innerhalb der Simulation fachlich etwas Relevantes passiert, sollte dies zuerst als Domain Event formuliert werden.
+Nicht ideal:
+field.crop_status = "harvested"
+dispatcher.dispatch(FieldOperationEvent(...))
+Bevorzugt:
+event = HarvestCompleted(field_id=field.id, date=today)
+apply(event)
+integration_event = map_to_integration_event(event)
+dispatcher.dispatch(integration_event)
+Faustregel
+Bei neuer Logik immer kurz fragen:
+Was ist fachlich passiert?
+Kann ich dieses Ereignis benennen?
+Kann der Zustand aus diesem Ereignis aktualisiert werden?
+Kann die externe Payload daraus abgeleitet werden?
+Wenn diese Fragen mit Ja beantwortet werden können, sollte die Logik eventbasiert umgesetzt werden.
+Zielbild
+Neue Logik soll möglichst diesem Muster folgen:
+Command
+→ Decision
+→ Domain Event
+→ apply(event)
+→ optional Integration / Logging / Persistenz
+Was nicht gemeint ist
+Dieses Prinzip bedeutet nicht, dass DigiSim sofort vollständig eventgesourct werden muss.
+Snapshots und bestehende Persistenzmechanismen bleiben weiterhin gültig.
+Ziel ist zunächst nur:
+bessere Nachvollziehbarkeit
+geringere Kopplung
+sauberere Erweiterbarkeit
+Besonders relevant für neue Features
+Dieses Prinzip ist besonders wichtig bei:
+neuen Operationstypen
+Bewässerungslogik
+neuen Entscheidungsregeln
+Replay- und Fast-Forward-Funktionen
+zusätzlicher Beobachtbarkeit oder Audit-Historie

--- a/config/settings.py
+++ b/config/settings.py
@@ -3,6 +3,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 import datetime
+from urllib.parse import urlparse
 
 from models.sim_context import SimContext
 from services.farm_sync_service import FarmSyncService, FieldData
@@ -15,6 +16,7 @@ logger = get_logger("config")
 class DaemonConfig:
     """Validierte Konfiguration für den Daemon-Start."""
     api_url: str
+    api_base_url: str
     api_token: str
     farm_id: int
     api_timeout: int
@@ -45,8 +47,13 @@ def load_and_validate_config() -> DaemonConfig:
     if missing:
         raise ValueError(f"Missing required environment variables: {', '.join(missing)}")
 
+    _api_url = os.environ["DIGIZERT_API_URL"]
+    _parsed = urlparse(_api_url)
+    _api_base_url = f"{_parsed.scheme}://{_parsed.netloc}"
+
     return DaemonConfig(
-        api_url=os.environ["DIGIZERT_API_URL"],
+        api_url=_api_url,
+        api_base_url=_api_base_url,
         api_token=os.environ["DIGIZERT_API_TOKEN"],
         farm_id=int(os.environ["FARM_ID"]),
         api_timeout=int(os.getenv("API_TIMEOUT_SECONDS", "10")),
@@ -69,7 +76,7 @@ def load_and_validate_config() -> DaemonConfig:
 
 def load_sim_contexts_from_api(config: DaemonConfig, state_manager=None) -> list[SimContext]:
     sync_service = FarmSyncService(
-        api_url=config.api_url,
+        api_url=config.api_base_url,
         api_token=config.api_token,
         timeout=config.api_timeout
     )

--- a/services/farm_sync_service.py
+++ b/services/farm_sync_service.py
@@ -28,23 +28,26 @@ class FarmSyncService:
         self.timeout = timeout
     
     def load_farm_fields(self, farm_id: int) -> List[FieldData]:
-        url = f"{self.api_url}/api/v1/enterprises/{farm_id}/fields"
-        headers = {"Authorization": f"Bearer {self.api_token}"}
+        url = f"{self.api_url}/api/v1/fields/{farm_id}/enterprise/"
+        headers = {"Authorization": f"Token {self.api_token}"}
         
         try:
-            with httpx.Client(timeout=self.timeout) as client:
-                response = client.get(url, headers=headers)
-                response.raise_for_status()
-                data = response.json()
-            
             fields = []
-            for result in data.get("results", []):
-                fields.append(FieldData(
-                    field_id=result["id"],
-                    field_name=result["name"],
-                    field_size=result["area"],
-                    soil_type=result.get("soil_type", "sand")
-                ))
+            with httpx.Client(timeout=self.timeout) as client:
+                while url:
+                    response = client.get(url, headers=headers)
+                    response.raise_for_status()
+                    data = response.json()
+                    
+                    for result in data.get("results", []):
+                        fields.append(FieldData(
+                            field_id=result["id"],
+                            field_name=result["name"],
+                            field_size=result["area"],
+                            soil_type=result.get("soil_type", "sand")
+                        ))
+                    
+                    url = data.get("next")
             
             logger.info("Farm fields loaded from API", farm_id=farm_id, field_count=len(fields))
             return fields

--- a/services/planting_plan_service.py
+++ b/services/planting_plan_service.py
@@ -219,7 +219,7 @@ class PlantingPlanService:
             event.application_category = operation.application_category
             event.application_amount = round(operation.application_amount * self.context.field_size, 2)
             event.application_unit = operation.application_unit
-            
+            event.field = self.context.field_id
 
             # variations for e.g. fuel consumption (in the range of 0.9 to 1.1 if set to 0.1 --> 10% variation in both directions)
             event.fuel = round(event.fuel * fuel_variation_factor, 2)

--- a/services/protection_plan_service.py
+++ b/services/protection_plan_service.py
@@ -141,7 +141,7 @@ class ProtectionPlanService:
             event.application_category = operation.application_category
             event.application_amount = round(operation.application_amount * self.context.field_size, 2)
             event.application_unit = operation.application_unit
-            
+            event.field = self.context.field_id
 
             # variations for e.g. fuel consumption (in the range of 0.9 to 1.1 if set to 0.1 --> 10% variation in both directions)
             event.fuel = round(event.fuel * fuel_variation_factor, 2)

--- a/utils/event_logger.py
+++ b/utils/event_logger.py
@@ -15,8 +15,6 @@ class EventLogger:
         if not event.machine:
             event.machine = "Fendt 719 Vario"
         
-        event.exa_id = 0
-        event.field = 0
         event.batch = None
 
         # anfügen


### PR DESCRIPTION
## Fixes

- **`farm_sync_service.py`**: Korrekter API-URL-Pfad (`/api/v1/fields/{id}/enterprise/`), `Bearer` → `Token` Auth-Header, Pagination-Support (lädt alle Seiten)
- **`planting_plan_service.py`**: `event.field = self.context.field_id` gesetzt
- **`protection_plan_service.py`**: `event.field = self.context.field_id` gesetzt  
- **`settings.py`**: `api_base_url` aus `api_url` abgeleitet für FarmSyncService
- **`utils/event_logger.py`**: Hardcoded `event.field = 0` Override entfernt (Root Cause der 400-Fehler)

## Ergebnis

`"successful": 20, "total": 20` — alle 20 Felder dispatchen Events mit `201 Created`