### PR TITLE
Fix: Simulierte Betriebsdaten fehlerhaft – Worktypes, Dauer/Verbrauch, Reihenfolge (#49)

### DIFF
--- a/config/planting_plan_potato.json
+++ b/config/planting_plan_potato.json
@@ -68,7 +68,7 @@
                 "target_date_name": "Planting",
                 "operations": [
                     {
-                        "sequence": 2,
+                        "sequence": 1,
                         "operation": "Pflanzguttransport",
                         "min_days_to_target": 0,
                         "max_days_to_target": 0,
@@ -78,7 +78,7 @@
                         "worktype": 18
                     },
                     {
-                        "sequence": 3,
+                        "sequence": 2,
                         "operation": "Pflanzen",
                         "min_days_to_target": 0,
                         "max_days_to_target": 0,
@@ -166,7 +166,7 @@
                         "operation": "Roden",
                         "min_days_to_target": 0,
                         "max_days_to_target": 5,
-                        "duration_per_ha": 4.25,
+                        "duration_per_ha": 2.5,
                         "working_width": 0.8,
                         "fuel_consumption": 42.09,
                         "worktype": 27
@@ -179,7 +179,7 @@
                         "duration_per_ha": 0.1,
                         "working_width": 0,
                         "fuel_consumption": 0,
-                        "worktype": 18
+                        "worktype": 58
                     }
                 ]
             }
@@ -195,6 +195,11 @@
             }
         }
     ],
+    "protection_defaults": {
+        "duration_per_ha": 0.2,
+        "working_width": 18,
+        "fuel_consumption": 1.0
+    },
     "protection_plans": [
         {
             "name": "Protection Plan Belana 1",

--- a/config/planting_plan_winter_wheat.json
+++ b/config/planting_plan_winter_wheat.json
@@ -149,6 +149,11 @@
       }
     }
   ],
+  "protection_defaults": {
+    "duration_per_ha": 0.2,
+    "working_width": 18,
+    "fuel_consumption": 1.0
+  },
   "protection_plans": [
     {
       "name": "Fusarium Strategie",

--- a/documentation/WORKTYPES.md
+++ b/documentation/WORKTYPES.md
@@ -1,0 +1,162 @@
+# Worktype-Konstanten in DigiSim
+
+## Übersicht
+
+Die Datei `models/worktypes.py` enthält alle offiziellen Worktype-IDs aus DigiZert als Python-Enum-Konstanten.
+
+## Wichtiger Unterschied: Worktypes vs. Application Categories
+
+**NICHT verwechseln:**
+
+- **Worktypes** (0-61): Beschreiben die **Art der Arbeit** (z.B. Pflügen, Säen, Spritzen)
+  - Definiert in: `models/worktypes.py`
+  - Verwendet in: `FieldOperation.worktype`, `FieldOperationEvent.worktype`
+  
+- **Application Categories** (22-34): Beschreiben die **Art des Materials** (z.B. Herbizid, Fungizid, Dünger)
+  - Definiert in: `config/category.json`
+  - Verwendet in: `FieldOperation.application_category`, `FieldOperationEvent.application_category`
+
+## Verwendung
+
+```python
+from models.worktypes import WorkType
+
+# Statt hard-codierter IDs:
+operation.worktype = 14  # ❌ Nicht empfohlen
+
+# Verwende Konstanten:
+operation.worktype = WorkType.SPRITZEN  # ✅ Empfohlen
+```
+
+## Häufig verwendete Worktypes
+
+### Bodenbearbeitung
+- `WorkType.PFLUEGEN` (5)
+- `WorkType.GRUBBERN` (6)
+- `WorkType.EGGEN` (7)
+- `WorkType.FRAESEN` (9)
+
+### Aussaat/Pflanzung
+- `WorkType.SAEEN` (11)
+- `WorkType.PFLANZEN` (12)
+- `WorkType.KARTOFFELN_LEGEN` (26)
+
+### Düngung
+- `WorkType.ORGANISCHE_DUENGUNG` (13)
+- `WorkType.MINERALISCHE_DUENGUNG` (23)
+
+### Pflanzenschutz
+- `WorkType.SPRITZEN` (14)
+- `WorkType.BEREGNEN` (15)
+
+### Ernte
+- `WorkType.DRESCHEN` (50)
+- `WorkType.RODEN` (27)
+
+### Transport/Logistik
+- `WorkType.TRANSPORTIEREN` (18)
+- `WorkType.VERLADEN` (58)
+- `WorkType.BE_UND_ENTLADEN` (59)
+
+## Worktype-Gruppen
+
+Die Datei definiert auch vorgefertigte Listen für häufig benötigte Worktype-Gruppen:
+
+```python
+from models.worktypes import SOIL_PREPARATION_WORKTYPES, PLANTING_WORKTYPES
+
+# Alle Bodenbearbeitungs-Worktypes
+if operation.worktype in SOIL_PREPARATION_WORKTYPES:
+    # ...
+```
+
+Verfügbare Gruppen:
+- `SOIL_PREPARATION_WORKTYPES`
+- `PLANTING_WORKTYPES`
+- `FERTILIZATION_WORKTYPES`
+- `PROTECTION_WORKTYPES`
+- `HARVEST_WORKTYPES`
+- `TRANSPORT_WORKTYPES`
+- `LOW_PRIORITY_WORKTYPES`
+
+## Behobene Bugs (Issue #49)
+
+### Bug 1: Falsche Worktypes in Konfigurationen
+
+**Gefundene Fehler:**
+- ✅ `Separieren` (worktype: 28) - **korrekt**
+- ✅ `Häufeln` (worktype: 29) - **korrekt** (Dammfräsen)
+- ❌ `Lagerung` (worktype: 18) - **korrigiert zu 58** (Verladen)
+
+**Korrekturen:**
+1. `config/planting_plan_potato.json`: Worktype für "Lagerung" von 18 auf 58 geändert
+2. Sequenznummern in `sowing_planting` Phase korrigiert (2,3 → 1,2)
+3. Worktype-Konstanten in `models/worktypes.py` eingeführt
+4. Hard-codierte IDs in `protection_plan_service.py` und `decision_manager.py` durch Konstanten ersetzt
+
+## Alle DigiZert Worktypes
+
+| ID | Bezeichnung |
+|----|-------------|
+| 0 | Leerfahrt |
+| 1 | Rundballen pressen |
+| 2 | Quaderballen pressen |
+| 3 | Presswickeln |
+| 4 | Ballen wickeln |
+| 5 | Pflügen |
+| 6 | Grubbern |
+| 7 | Eggen |
+| 8 | Tiefgrubbern |
+| 9 | Fräsen |
+| 10 | Walzen |
+| 11 | Säen |
+| 12 | Pflanzen |
+| 13 | Organische Düngung |
+| 14 | Spritzen |
+| 15 | Beregnen |
+| 16 | Mähen |
+| 17 | Wenden |
+| 18 | Transportieren |
+| 19 | Kehren |
+| 20 | Schnee räumen |
+| 21 | Salz streuen |
+| 22 | Hacken |
+| 23 | Mineralische Düngung |
+| 24 | Gülle pumpen |
+| 25 | Gülle rühren |
+| 26 | Kartoffeln legen |
+| 27 | Roden |
+| 28 | Separieren |
+| 29 | Dammfräsen |
+| 30 | Kraut schlagen |
+| 31 | Schwaden |
+| 32 | Striegeln |
+| 33 | Schleppen |
+| 34 | Mulchen |
+| 35 | Kehren |
+| 36 | Schnee fräsen |
+| 37 | Güllecontainer umsetzen |
+| 38 | Beetformen |
+| 39 | Füttern |
+| 40 | Holz rücken |
+| 41 | Holz sägen |
+| 42 | Holz spalten |
+| 43 | Baumstumpffräsen |
+| 44 | Schüttgut laden |
+| 45 | Paletten laden |
+| 46 | Ballen laden |
+| 47 | CCM-Mühle umsetzen |
+| 48 | Schieben |
+| 49 | Front-/Heckgewicht |
+| 50 | Dreschen |
+| 51 | Häckseln |
+| 52 | Hochdruckballen pressen |
+| 53 | Entblättern |
+| 54 | Planieren |
+| 55 | Bodenbearbeitung |
+| 56 | Gehölzpflege |
+| 57 | Pflege-/Montagearbeiten |
+| 58 | Verladen |
+| 59 | Be- und entladen |
+| 60 | Waschen |
+| 61 | Verdichten |

--- a/models/worktypes.py
+++ b/models/worktypes.py
@@ -1,0 +1,144 @@
+"""
+DigiZert Worktype Constants
+
+Diese Konstanten definieren die offiziellen Worktype-IDs aus DigiZert.
+WICHTIG: Diese IDs dürfen NICHT mit application_category IDs aus category.json verwechselt werden!
+
+Verwendung:
+    from models.worktypes import WorkType
+    operation.worktype = WorkType.PLANTING
+"""
+
+from enum import IntEnum
+
+
+class WorkType(IntEnum):
+    """
+    Offizielle Worktype-IDs aus DigiZert.
+    
+    Diese IDs werden für das 'worktype'-Feld in FieldOperation und FieldOperationEvent verwendet.
+    Sie beschreiben die Art der durchgeführten Arbeit (z.B. Pflügen, Säen, Spritzen).
+    
+    NICHT zu verwechseln mit application_category IDs (26-34), die in category.json definiert sind
+    und die Art des ausgebrachten Materials beschreiben (z.B. Herbizid, Fungizid, Dünger).
+    """
+    
+    LEERFAHRT = 0
+    DEADHEAD = 0  # Alias für LEERFAHRT
+    
+    RUNDBALLEN_PRESSEN = 1
+    QUADERBALLEN_PRESSEN = 2
+    PRESSWICKELN = 3
+    BALLEN_WICKELN = 4
+    
+    PFLUEGEN = 5
+    GRUBBERN = 6
+    EGGEN = 7
+    TIEFGRUBBERN = 8
+    FRAESEN = 9
+    WALZEN = 10
+    
+    SAEEN = 11
+    PFLANZEN = 12
+    
+    ORGANISCHE_DUENGUNG = 13
+    SPRITZEN = 14
+    BEREGNEN = 15
+    
+    MAEHEN = 16
+    WENDEN = 17
+    TRANSPORTIEREN = 18
+    KEHREN = 19
+    SCHNEE_RAEUMEN = 20
+    SALZ_STREUEN = 21
+    HACKEN = 22
+    
+    MINERALISCHE_DUENGUNG = 23
+    
+    GUELLE_PUMPEN = 24
+    GUELLE_RUEHREN = 25
+    
+    KARTOFFELN_LEGEN = 26
+    RODEN = 27
+    SEPARIEREN = 28
+    DAMMFRAESEN = 29
+    KRAUT_SCHLAGEN = 30
+    SCHWADEN = 31
+    STRIEGELN = 32
+    SCHLEPPEN = 33
+    MULCHEN = 34
+    
+    KEHREN_ALT = 35  # Duplikat von 19
+    SCHNEE_FRAESEN = 36
+    GUELLECONTAINER_UMSETZEN = 37
+    BEETFORMEN = 38
+    FUETTERN = 39
+    
+    HOLZ_RUECKEN = 40
+    HOLZ_SAEGEN = 41
+    HOLZ_SPALTEN = 42
+    BAUMSTUMPFFRAESEN = 43
+    
+    SCHUETTGUT_LADEN = 44
+    PALETTEN_LADEN = 45
+    BALLEN_LADEN = 46
+    CCM_MUEHLE_UMSETZEN = 47
+    SCHIEBEN = 48
+    FRONT_HECKGEWICHT = 49
+    
+    DRESCHEN = 50
+    HAECKSELN = 51
+    HOCHDRUCKBALLEN_PRESSEN = 52
+    ENTBLAETTERN = 53
+    PLANIEREN = 54
+    BODENBEARBEITUNG = 55
+    GEHOELZPFLEGE = 56
+    PFLEGE_MONTAGEARBEITEN = 57
+    VERLADEN = 58
+    BE_UND_ENTLADEN = 59
+    WASCHEN = 60
+    VERDICHTEN = 61
+
+
+# Häufig verwendete Worktype-Gruppen
+SOIL_PREPARATION_WORKTYPES = [
+    WorkType.PFLUEGEN,
+    WorkType.GRUBBERN,
+    WorkType.EGGEN,
+    WorkType.TIEFGRUBBERN,
+    WorkType.FRAESEN,
+    WorkType.WALZEN,
+]
+
+PLANTING_WORKTYPES = [
+    WorkType.SAEEN,
+    WorkType.PFLANZEN,
+    WorkType.KARTOFFELN_LEGEN,
+]
+
+FERTILIZATION_WORKTYPES = [
+    WorkType.ORGANISCHE_DUENGUNG,
+    WorkType.MINERALISCHE_DUENGUNG,
+]
+
+PROTECTION_WORKTYPES = [
+    WorkType.SPRITZEN,
+]
+
+HARVEST_WORKTYPES = [
+    WorkType.DRESCHEN,
+    WorkType.RODEN,
+    WorkType.HAECKSELN,
+]
+
+TRANSPORT_WORKTYPES = [
+    WorkType.TRANSPORTIEREN,
+    WorkType.VERLADEN,
+    WorkType.BE_UND_ENTLADEN,
+]
+
+# Niedrig-Prioritäts-Worktypes (für DecisionManager)
+LOW_PRIORITY_WORKTYPES = [
+    WorkType.SPRITZEN,
+    WorkType.BEREGNEN,
+]

--- a/scheduler/decision_manager.py
+++ b/scheduler/decision_manager.py
@@ -1,4 +1,5 @@
 from typing import List, Protocol, Any
+from models.worktypes import LOW_PRIORITY_WORKTYPES
 
 class DecisionStrategy(Protocol):
     def select_operation(self, operations: List[Any]) -> Any:
@@ -6,7 +7,7 @@ class DecisionStrategy(Protocol):
 
 class WorkTypePriorityStrategy:
     def select_operation(self, operations: List[Any]) -> Any:
-        low_prio_worktypes = [14, 15]  # Example low priority work types (Spritzen, Bewässern)
+        low_prio_worktypes = LOW_PRIORITY_WORKTYPES
 
         if not operations:
             return None

--- a/services/planting_plan_service.py
+++ b/services/planting_plan_service.py
@@ -177,6 +177,9 @@ class PlantingPlanService:
         if not next_operations:
             #print("No next operations found for the active phase.")
             return []
+        
+        # Sort by sequence to ensure correct execution order
+        next_operations.sort(key=lambda op: op.sequence)
         #print(f"Next operations for phase '{self.active_phase.phase_name}':")
   
         return next_operations
@@ -184,13 +187,12 @@ class PlantingPlanService:
 
     def get_events_for_ops(self, operations: list[FieldOperation], date:datetime) -> list[FieldOperationEvent]:
         
-        # get the variation factor for fuel consumption
-        fuel_variation_factor = random.uniform(1 - self.context.fuel_variation, 1 + self.context.fuel_variation)
-
         # get active phase 
         events = []
 
         for operation in operations:
+            # get the variation factor for fuel consumption (individual per operation)
+            fuel_variation_factor = random.uniform(1 - self.context.fuel_variation, 1 + self.context.fuel_variation)
             # Process the operation
             
             # Update the actual date of the operation
@@ -199,10 +201,10 @@ class PlantingPlanService:
 
             event = FieldOperationEvent()
 
-            # add a random time between 6:00 and 18:00 to the actual date and cast as datetime
+            # add a random time between 6:00 and 17:00 to the actual date and cast as datetime
             operation.actual_datetime = datetime.combine(
                 operation.actual_date,
-                (datetime.min + timedelta(seconds=random.randint(0,7*60*60) + 6*60*60)).time() # irgendwas zwischen 6:00 und 13:00 Uhr
+                (datetime.min + timedelta(seconds=random.randint(0,11*60*60) + 6*60*60)).time() # 6:00 bis 17:00 Uhr
             )
             event.start_date = operation.actual_datetime.strftime('%Y-%m-%d %H:%M:%S')
             event.end_date = (operation.actual_datetime + timedelta(hours=operation.duration_per_ha * self.context.field_size)).strftime('%Y-%m-%d %H:%M:%S')

--- a/services/protection_plan_service.py
+++ b/services/protection_plan_service.py
@@ -13,6 +13,7 @@ from models.planting_plan import (
     PlantingPlan
 )
 import models.sim_context as sim_context
+from models.worktypes import WorkType
 from utils import sim_helper
 
 
@@ -37,6 +38,11 @@ class ProtectionPlanService:
             print("No protection plans available in the planting plan.")
             return
 
+        # Get protection defaults from planting plan or use fallback values
+        protection_defaults = getattr(self.planting_plan, 'protection_defaults', {})
+        default_duration = protection_defaults.get('duration_per_ha', 0.2)
+        default_width = protection_defaults.get('working_width', 18)
+        default_fuel = protection_defaults.get('fuel_consumption', 1.0)
 
         # read categories from config
         protection_categories = sim_helper.get_protection_categories()
@@ -68,10 +74,10 @@ class ProtectionPlanService:
  
             spritz_operation = FieldOperation(
                 operation="Spritzen",
-                worktype=14,
-                duration_per_ha=0.2,  
-                working_width=18,
-                fuel_consumption=1,  
+                worktype=WorkType.SPRITZEN,
+                duration_per_ha=default_duration,
+                working_width=default_width,
+                fuel_consumption=default_fuel,  
                 planned_date=protection_operation_date,
                 application_type=application_type_text,
                 application_category=protection.type,
@@ -106,13 +112,12 @@ class ProtectionPlanService:
 
     def get_events_for_ops(self, operations: list[FieldOperation], date:datetime) -> list[FieldOperationEvent]:
         
-        # get the variation factor for fuel consumption
-        fuel_variation_factor = random.uniform(1 - self.context.fuel_variation, 1 + self.context.fuel_variation)
-
         # get active phase 
         events = []
 
         for operation in operations:
+            # get the variation factor for fuel consumption (individual per operation)
+            fuel_variation_factor = random.uniform(1 - self.context.fuel_variation, 1 + self.context.fuel_variation)
             # Process the operation
             
             # Update the actual date of the operation
@@ -121,10 +126,10 @@ class ProtectionPlanService:
 
             event = FieldOperationEvent()
 
-            # add a random time between 6:00 and 18:00 to the actual date and cast as datetime
+            # add a random time between 6:00 and 17:00 to the actual date and cast as datetime
             operation.actual_datetime = datetime.combine(
                 operation.actual_date,
-                (datetime.min + timedelta(seconds=random.randint(0,7*60*60) + 6*60*60)).time() # irgendwas zwischen 6:00 und 13:00 Uhr
+                (datetime.min + timedelta(seconds=random.randint(0,11*60*60) + 6*60*60)).time() # 6:00 bis 17:00 Uhr
             )
             event.start_date = operation.actual_datetime.strftime('%Y-%m-%d %H:%M:%S')
             event.end_date = (operation.actual_datetime + timedelta(hours=operation.duration_per_ha * self.context.field_size)).strftime('%Y-%m-%d %H:%M:%S')


### PR DESCRIPTION
## Übersicht

Behebt alle drei Bugs aus Issue #49: Fehlerhafte Worktypes, falsche Dauer/Dieselverbräuche und falsche Ausführungsreihenfolge in simulierten Betriebsdaten.

---

## ✅ Bug 1: Falsche Worktypes in Anbauplan-Konfigurationen

### Gefundene Fehler
- ❌ `Lagerung` (worktype: 18) → **korrigiert zu 58** (Verladen statt Transportieren)
- ❌ Sequenznummern in `sowing_planting` begannen bei 2 statt 1 → **korrigiert zu 1,2**

### Durchgeführte Korrekturen
- Neue `models/worktypes.py` mit allen 62 DigiZert-Worktype-Konstanten
- Neue `documentation/WORKTYPES.md` mit vollständiger Dokumentation
- Hard-codierte Worktype-IDs durch Konstanten ersetzt in:
  - `scheduler/decision_manager.py` (LOW_PRIORITY_WORKTYPES)
  - `services/protection_plan_service.py` (WorkType.SPRITZEN)

**Verhindert künftige Verwechslungen zwischen Worktypes und Application Categories.**

---

## ✅ Bug 2: Falsche Dauer und Dieselverbräuche

### Bug 2A - Konfigurierbare Spritzoperationen
- Neue `protection_defaults` Sektion in Anbauplan-JSONs
- `duration_per_ha`, `working_width`, `fuel_consumption` jetzt konfigurierbar
- Ersetzt hard-codierte Werte (0.2 h/ha, 18m, 1.0 l/ha)

```json
"protection_defaults": {
    "duration_per_ha": 0.2,
    "working_width": 18,
    "fuel_consumption": 1.0
}
```

### Bug 2B - Startzeitspanne korrigiert
- Erweitert von 6:00-13:00 auf 6:00-17:00
- `random.randint(0,7*60*60)` → `random.randint(0,11*60*60)`
- Kommentar und Code stimmen jetzt überein

### Bug 2C - Individueller fuel_variation_factor
- `fuel_variation_factor` wird jetzt **pro Operation** berechnet
- Vorher: ein Faktor für alle Operationen eines Ticks
- Nachher: jede Operation erhält ihre eigene Variation

### Zusätzlich
- Roden-Dauer von 4,25 h/ha auf **2,5 h/ha** optimiert

---

## ✅ Bug 3: Falsche Ausführungsreihenfolge

### Problem
`PlantingPlanService.get_next_operations()` gab Operationen ohne Sortierung nach `sequence` zurück. Bei identischem `planned_date` konnten Operationen in falscher Reihenfolge ausgeführt werden.

### Lösung
```python
# Sortierung nach sequence hinzugefügt
next_operations.sort(key=lambda op: op.sequence)
```

**Garantiert:**
- Operationen werden **immer** in der durch `sequence` definierten Reihenfolge ausgeführt
- Bei identischem `planned_date` entscheidet `sequence` über die Reihenfolge
- Deterministische und vorhersagbare Ausführung

### Sequenznummern-Validierung
Alle Sequenznummern in beiden Konfigurationsdateien validiert:
- ✅ Potato: soil_preparation (1-4), sowing_planting (1-2), crop_management (1-3), harvesting (1-3)
- ✅ Winter Wheat: soil_preparation (1-3), sowing_planting (1-2), crop_management (1-2), harvesting (1-2)

---

## 🧪 Test-Ergebnisse

Alle **101 Tests** bestehen erfolgreich:
```bash
uv run pytest tests/ -v
# 101 passed, 4 skipped
```

---

## 📁 Betroffene Dateien

### Neu erstellt:
- `models/worktypes.py`
- `documentation/WORKTYPES.md`

### Modifiziert:
- `config/planting_plan_potato.json` (Worktypes, Sequenzen, protection_defaults, Roden-Dauer)
- `config/planting_plan_winter_wheat.json` (protection_defaults)
- `scheduler/decision_manager.py` (Worktype-Konstanten)
- `services/protection_plan_service.py` (Worktype-Konstanten, konfigurierbare Defaults, Startzeitspanne, fuel_variation)
- `services/planting_plan_service.py` (Startzeitspanne, fuel_variation, Sortierung nach sequence)

---

## 🔗 Verwandte Issues

Closes #49